### PR TITLE
fix: add back sc-provider to cli

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@inquirer/prompts": "^3.0.2",
     "@polkadot-api/json-rpc-provider": "workspace:*",
+    "@polkadot-api/sc-provider": "workspace:*",
     "@polkadot-api/substrate-bindings": "workspace:*",
     "@polkadot-api/substrate-client": "workspace:*",
     "@polkadot-api/substrate-codegen": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@polkadot-api/json-rpc-provider':
         specifier: workspace:*
         version: link:../json-rpc-provider
+      '@polkadot-api/sc-provider':
+        specifier: workspace:*
+        version: link:../sc-provider
       '@polkadot-api/substrate-bindings':
         specifier: workspace:*
         version: link:../substrate-bindings


### PR DESCRIPTION
Need to add it back since its being used in smolldot worker

https://github.com/paritytech/polkadot-api/blob/main/packages/cli/src/smolldot-worker.ts#L3