### PR TITLE
substrate-client: `event` to `type`

### DIFF
--- a/experiments/src/all-nominators.ts
+++ b/experiments/src/all-nominators.ts
@@ -44,11 +44,11 @@ export const getAllNominators = (): Promise<any> =>
     const chainHeadFollower = chainHead(
       true,
       (message) => {
-        if (message.event === "newBlock") {
+        if (message.type === "newBlock") {
           chainHeadFollower.unpin([message.blockHash])
           return
         }
-        if (requested || message.event !== "initialized") return
+        if (requested || message.type !== "initialized") return
         const latestFinalized = message.finalizedBlockHash
         console.log({ latestFinalized })
         requested = true

--- a/experiments/src/getMetadata.ts
+++ b/experiments/src/getMetadata.ts
@@ -54,11 +54,11 @@ export const getMetadata = (): Promise<Metadata> =>
     const chainHeadFollower = chainHead(
       true,
       (message) => {
-        if (message.event === "newBlock") {
+        if (message.type === "newBlock") {
           chainHeadFollower.unpin([message.blockHash])
           return
         }
-        if (requested || message.event !== "initialized") return
+        if (requested || message.type !== "initialized") return
         const latestFinalized = message.finalizedBlockHash
         if (requested) return
         requested = true

--- a/packages/client/src/create-client.ts
+++ b/packages/client/src/create-client.ts
@@ -88,15 +88,15 @@ export function createPullClient<
   const runtime$ = chainHead$.pipe(
     scan(
       (acc, event) => {
-        if (event.event === "initialized") {
+        if (event.type === "initialized") {
           acc.candidates.clear()
           acc.current = event.finalizedBlockRuntime
         }
 
-        if (event.event === "newBlock" && event.newRuntime)
+        if (event.type === "newBlock" && event.newRuntime)
           acc.candidates.set(event.blockHash, event.newRuntime)
 
-        if (event.event !== "finalized") return acc
+        if (event.type !== "finalized") return acc
 
         const [newRuntimeHash] = event.finalizedBlockHashes
           .filter((h) => acc.candidates.has(h))
@@ -117,8 +117,8 @@ export function createPullClient<
 
   const finalized$: Observable<string> = chainHead$.pipe(
     mergeMap((e) => {
-      if (e.event === "initialized") return [e.finalizedBlockHash]
-      if (e.event === "finalized") return e.finalizedBlockHashes
+      if (e.type === "initialized") return [e.finalizedBlockHash]
+      if (e.type === "finalized") return e.finalizedBlockHashes
       return []
     }),
     shareReplay(1),

--- a/packages/substrate-client/src/chainhead/chainhead.ts
+++ b/packages/substrate-client/src/chainhead/chainhead.ts
@@ -50,7 +50,7 @@ export function getChainHead(
       if (isOperationEvent(event))
         return subscriptions.next(event.operationId, event)
 
-      if (event.event !== "stop") return onFollowEvent(event as any)
+      if (event.type !== "stop") return onFollowEvent(event as any)
 
       onFollowError(new StopError())
       unfollow(false)

--- a/packages/substrate-client/src/chainhead/internal-types.ts
+++ b/packages/substrate-client/src/chainhead/internal-types.ts
@@ -1,23 +1,23 @@
 // Common
 export interface Inaccessible {
-  event: "inaccessible"
+  type: "inaccessible"
 }
 
 export interface Disjoint {
-  event: "disjoint"
+  type: "disjoint"
 }
 
 export interface FError {
-  event: "error"
+  type: "error"
   error: string
 }
 
 export interface Stop {
-  event: "stop"
+  type: "stop"
 }
 
 export interface Done {
-  event: "done"
+  type: "done"
 }
 
 // operation events
@@ -26,27 +26,27 @@ interface OperationEvent {
 }
 
 export type OperationWaitingForContinue = OperationEvent & {
-  event: "operationWaitingForContinue"
+  type: "operationWaitingForContinue"
 }
 
 export type OperationInaccessible = OperationEvent & {
-  event: "operationInaccessible"
+  type: "operationInaccessible"
 }
 
 export type OperationError = OperationEvent & {
-  event: "operationError"
+  type: "operationError"
   error: string
 }
 
 export type CommonOperationEvents = OperationInaccessible | OperationError
 
 export type OperationBodyDone = OperationEvent & {
-  event: "operationBodyDone"
+  type: "operationBodyDone"
   value: Array<string>
 }
 
 export type OperationCallDone = OperationEvent & {
-  event: "operationCallDone"
+  type: "operationCallDone"
   output: string
 }
 
@@ -58,12 +58,12 @@ export interface StorageItemResponse {
 }
 
 export type OperationStorageItems = OperationEvent & {
-  event: "operationStorageItems"
+  type: "operationStorageItems"
   items: Array<StorageItemResponse>
 }
 
 export type OperationStorageDone = OperationEvent & {
-  event: "operationStorageDone"
+  type: "operationStorageDone"
 }
 
 export type OperationEvents =

--- a/packages/substrate-client/src/chainhead/operation-promise.ts
+++ b/packages/substrate-client/src/chainhead/operation-promise.ts
@@ -8,7 +8,7 @@ import {
 } from "./errors"
 
 export const createOperationPromise =
-  <I extends { operationId: string; event: string }, O, A extends Array<any>>(
+  <I extends { operationId: string; type: string }, O, A extends Array<any>>(
     operationName: string,
     factory: (
       ...args: A
@@ -43,9 +43,9 @@ export const createOperationPromise =
           done = followSubscription(response.operationId, {
             next: (e) => {
               const _e = e as CommonOperationEvents
-              if (_e.event === "operationError") {
+              if (_e.type === "operationError") {
                 rej(new OperationError(_e.error))
-              } else if (_e.event === "operationInaccessible") {
+              } else if (_e.type === "operationInaccessible") {
                 rej(new OperationInaccessibleError())
               } else {
                 logicCb(e as I, _res, _rej)

--- a/packages/substrate-client/src/chainhead/public-types.ts
+++ b/packages/substrate-client/src/chainhead/public-types.ts
@@ -11,7 +11,7 @@ export interface Runtime {
 }
 
 export interface Initialized {
-  event: "initialized"
+  type: "initialized"
   finalizedBlockHash: string
 }
 
@@ -20,7 +20,7 @@ export type InitializedWithRuntime = Initialized & {
 }
 
 export interface NewBlock {
-  event: "newBlock"
+  type: "newBlock"
   blockHash: string
   parentBlockHash: string
 }
@@ -30,12 +30,12 @@ export type NewBlockWithRuntime = NewBlock & {
 }
 
 export interface BestBlockChanged {
-  event: "bestBlockChanged"
+  type: "bestBlockChanged"
   bestBlockHash: string
 }
 
 export interface Finalized {
-  event: "finalized"
+  type: "finalized"
   finalizedBlockHashes: Array<string>
   prunedBlockHashes: Array<string>
 }

--- a/packages/substrate-client/src/chainhead/storage.ts
+++ b/packages/substrate-client/src/chainhead/storage.ts
@@ -75,7 +75,7 @@ export const createStorageFn = createOperationPromise(
       e: OperationStorageItems | OperationStorageDone,
       res: (x: StorageResponse) => void,
     ) => {
-      if (e.event === "operationStorageDone") return res(result)
+      if (e.type === "operationStorageDone") return res(result)
 
       e.items.forEach((item) => {
         if (item.value) {

--- a/packages/substrate-client/src/transaction/transaction.ts
+++ b/packages/substrate-client/src/transaction/transaction.ts
@@ -10,7 +10,7 @@ import type {
 } from "./types"
 
 type TerminalEvent = TxDropped | TxInvalid | TxFinalized | TxError
-const terminalEvents: Set<string> = new Set<TerminalEvent["event"]>([
+const terminalEvents: Set<string> = new Set<TerminalEvent["type"]>([
   "dropped",
   "invalid",
   "finalized",
@@ -18,13 +18,13 @@ const terminalEvents: Set<string> = new Set<TerminalEvent["event"]>([
 ])
 
 function isTerminalEvent(event: TxEvent): event is TerminalEvent {
-  return terminalEvents.has(event.event)
+  return terminalEvents.has(event.type)
 }
 
 type ErrorEvents = TxDropped | TxInvalid | TxError
 
 export interface ITxError {
-  type: ErrorEvents["event"]
+  type: ErrorEvents["type"]
   error: string
 }
 
@@ -32,8 +32,8 @@ export class TransactionError extends Error implements ITxError {
   type
   error
   constructor(e: ErrorEvents) {
-    super(`TxError: ${e.event} - ${e.error}`)
-    this.type = e.event
+    super(`TxError: ${e.type} - ${e.error}`)
+    this.type = e.type
     this.error = e.error
     this.name = "TransactionError"
   }
@@ -49,7 +49,7 @@ export const getTransaction =
             if (isTerminalEvent(event)) {
               done()
               cancel = noop
-              if (event.event !== "finalized")
+              if (event.type !== "finalized")
                 return error(new TransactionError(event))
             }
             next(event)

--- a/packages/substrate-client/src/transaction/types.ts
+++ b/packages/substrate-client/src/transaction/types.ts
@@ -1,16 +1,16 @@
 import type { UnsubscribeFn } from ".."
 
 export interface TxValidated {
-  event: "validated"
+  type: "validated"
 }
 
 export interface TxBroadcasted {
-  event: "broadcasted"
+  type: "broadcasted"
   numPeers: number
 }
 
 export interface TxBestChainBlockIncluded {
-  event: "bestChainBlockIncluded"
+  type: "bestChainBlockIncluded"
   block: {
     hash: string
     index: number
@@ -18,7 +18,7 @@ export interface TxBestChainBlockIncluded {
 }
 
 export interface TxFinalized {
-  event: "finalized"
+  type: "finalized"
   block: {
     hash: string
     index: number
@@ -26,18 +26,18 @@ export interface TxFinalized {
 }
 
 export interface TxInvalid {
-  event: "invalid"
+  type: "invalid"
   error: string
 }
 
 export interface TxDropped {
-  event: "dropped"
+  type: "dropped"
   broadcasted: boolean
   error: string
 }
 
 export interface TxError {
-  event: "error"
+  type: "error"
   error: string
 }
 

--- a/packages/substrate-client/tests/chainHead-operations.spec.ts
+++ b/packages/substrate-client/tests/chainHead-operations.spec.ts
@@ -20,7 +20,7 @@ describe.each([
     ["someHash"] as [string],
     [
       {
-        event: "operationBodyDone",
+        type: "operationBodyDone",
         value: ["tx1", "tx2"],
       },
     ],
@@ -33,7 +33,7 @@ describe.each([
     ["someHash", "someFnName", "someCallParams"] as [string, string, string],
     [
       {
-        event: "operationCallDone",
+        type: "operationCallDone",
         output: "operationCallOutput",
       },
     ],
@@ -56,7 +56,7 @@ describe.each([
     ["someHash", [{ key: "someStorageKey", type: "value" }], null],
     [
       {
-        event: "operationStorageItems",
+        type: "operationStorageItems",
         items: [
           {
             key: "someStorageKey",
@@ -65,7 +65,7 @@ describe.each([
         ],
       },
       {
-        event: "operationStorageDone",
+        type: "operationStorageDone",
       },
     ],
     {
@@ -180,7 +180,7 @@ describe.each([
       } = setupChainHeadOperationSubscription(op, ...args)
 
       sendOperationNotification({
-        event: "operationInaccessible",
+        type: "operationInaccessible",
       })
 
       return expect(operationPromise).rejects.toEqual(
@@ -196,7 +196,7 @@ describe.each([
 
       const error = "something went wrong"
       sendOperationNotification({
-        event: "operationError",
+        type: "operationError",
         error,
       })
 

--- a/packages/substrate-client/tests/chainHead.spec.ts
+++ b/packages/substrate-client/tests/chainHead.spec.ts
@@ -27,7 +27,7 @@ describe("chainHead", () => {
     } = setupChainHeadWithSubscription()
 
     const initialized = {
-      event: "initialized",
+      type: "initialized",
       finalizedBlockHash:
         "0x0000000000000000000000000000000000000000000000000000000000000000",
       finalizedBlockRuntime:
@@ -43,7 +43,7 @@ describe("chainHead", () => {
     expect(onError).not.toHaveBeenCalled()
 
     const newBlock = {
-      event: "newBlock",
+      type: "newBlock",
       blockHash:
         "0x0000000000000000000000000000000000000000000000000000000000000000",
       parentBlockHash:
@@ -59,7 +59,7 @@ describe("chainHead", () => {
     expect(onError).not.toHaveBeenCalled()
 
     const operationBodyDone = {
-      event: "operationBodyDone",
+      type: "operationBodyDone",
       operationId: "someOperationId",
       value: [""],
     }
@@ -72,7 +72,7 @@ describe("chainHead", () => {
     expect(onError).not.toHaveBeenCalled()
 
     const bestBlockChanged = {
-      event: "bestBlockChanged",
+      type: "bestBlockChanged",
       bestBlockHash:
         "0x0000000000000000000000000000000000000000000000000000000000000000",
     }
@@ -103,7 +103,7 @@ describe("chainHead", () => {
     expect(onError).not.toHaveBeenCalled()
 
     const initialized = {
-      event: "initialized",
+      type: "initialized",
       finalizedBlockHash:
         "0x0000000000000000000000000000000000000000000000000000000000000000",
       finalizedBlockRuntime:
@@ -142,7 +142,7 @@ describe("chainHead", () => {
     ])
 
     const initialized = {
-      event: "initialized",
+      type: "initialized",
       finalizedBlockHash:
         "0x0000000000000000000000000000000000000000000000000000000000000000",
       finalizedBlockRuntime:
@@ -162,7 +162,7 @@ describe("chainHead", () => {
     } = setupChainHeadWithSubscription()
 
     sendSubscription({
-      result: { event: "stop" },
+      result: { type: "stop" },
     })
 
     expect(onMsg).not.toHaveBeenCalled()
@@ -171,7 +171,7 @@ describe("chainHead", () => {
 
     sendSubscription({
       result: {
-        event: "initialized",
+        type: "initialized",
         finalizedBlockHash:
           "0x0000000000000000000000000000000000000000000000000000000000000000",
         finalizedBlockRuntime:
@@ -222,7 +222,7 @@ describe("chainHead", () => {
     })
 
     sendSubscription({
-      result: { event: "stop" },
+      result: { type: "stop" },
     })
 
     return Promise.all(
@@ -250,7 +250,7 @@ describe("chainHead", () => {
       call("", "", ""),
     ]
     sendSubscription({
-      result: { event: "stop" },
+      result: { type: "stop" },
     })
 
     return Promise.all(

--- a/packages/substrate-client/tests/storage.spec.ts
+++ b/packages/substrate-client/tests/storage.spec.ts
@@ -216,11 +216,11 @@ describe.each([true, false])("storage correctness", (mergeItems) => {
           ]
 
       sendOperationNotification({
-        event: "operationStorageItems",
+        type: "operationStorageItems",
         items,
       })
       sendOperationNotification({
-        event: "operationStorageDone",
+        type: "operationStorageDone",
       })
 
       const expected = {

--- a/packages/substrate-client/tests/transaction.spec.ts
+++ b/packages/substrate-client/tests/transaction.spec.ts
@@ -57,7 +57,7 @@ describe("transaction", () => {
       fixtures: { sendMessage, sendSubscription, onMsg, onError },
     } = setupTxWithSubscription()
 
-    const validated = { event: "validated" }
+    const validated = { type: "validated" }
     sendSubscription({
       result: validated,
     })
@@ -66,7 +66,7 @@ describe("transaction", () => {
     expect(onMsg).toHaveBeenCalledWith(validated)
     expect(onError).not.toHaveBeenCalled()
 
-    const broadcasted = { event: "broadcasted", numPeers: 2 }
+    const broadcasted = { type: "broadcasted", numPeers: 2 }
     sendSubscription({
       result: broadcasted,
     })
@@ -78,7 +78,7 @@ describe("transaction", () => {
     sendMessage({
       params: {
         subscription: "wrongSubscriptionId",
-        result: { event: "broadcasted", numPeers: 5 },
+        result: { type: "broadcasted", numPeers: 5 },
       },
     })
 
@@ -86,7 +86,7 @@ describe("transaction", () => {
     expect(onError).not.toHaveBeenCalled()
 
     const finalized = {
-      event: "finalized",
+      type: "finalized",
       block: {
         hash: "someHash",
         index: "1",
@@ -121,7 +121,7 @@ describe("transaction", () => {
     sendMessage({
       params: {
         subscription: SUBSCRIPTION_ID,
-        result: { event: "validated" },
+        result: { type: "validated" },
       },
     })
     expect(onMsg).not.toHaveBeenCalled()
@@ -150,7 +150,7 @@ describe("transaction", () => {
     ])
 
     sendSubscription({
-      result: { event: "validated" },
+      result: { type: "validated" },
     })
     expect(onMsg).not.toHaveBeenCalled()
     expect(onError).not.toHaveBeenCalled()
@@ -166,17 +166,17 @@ describe("transaction", () => {
 
       const error = `${eventType}: something wrong happened`
       sendSubscription({
-        result: { event: eventType, error },
+        result: { type: eventType, error },
       })
 
       expect(onMsg).not.toHaveBeenCalled()
       expect(onError).toHaveBeenCalledOnce()
       expect(onError).toHaveBeenCalledWith(
-        new TransactionError({ event: eventType as any, error }),
+        new TransactionError({ type: eventType as any, error }),
       )
 
       sendSubscription({
-        result: { event: "broadcasted", numPeers: 5 },
+        result: { type: "broadcasted", numPeers: 5 },
       })
 
       expect(onMsg).not.toHaveBeenCalled()
@@ -193,7 +193,7 @@ describe("transaction", () => {
       fixtures: { sendSubscription, getNewMessages, onMsg, onError },
     } = setupTxWithSubscription()
 
-    const finalizedEvent = { event: "finalized" }
+    const finalizedEvent = { type: "finalized" }
     sendSubscription({
       result: finalizedEvent,
     })
@@ -203,7 +203,7 @@ describe("transaction", () => {
     expect(onError).not.toHaveBeenCalled()
 
     sendSubscription({
-      result: { event: "broadcasted", numPeers: 5 },
+      result: { type: "broadcasted", numPeers: 5 },
     })
 
     expect(onMsg).toHaveBeenCalledOnce()


### PR DESCRIPTION
This PR amends a wrong that's been driving me nuts for a while: when I created the `substrate-client`, I mistakenly named the property used for the discriminated unions `event`, rather than naming it `type`. As a result we had lots of code that looked like this `if (event.event === "started")`, etc, etc.

I rather addressing this issue before it's too late.