### PR TITLE
fix(substrate-client): storage type coercion

### DIFF
--- a/packages/substrate-client/src/chainhead/storage.ts
+++ b/packages/substrate-client/src/chainhead/storage.ts
@@ -1,4 +1,5 @@
-import { ClientRequest, OperationLimitError, StorageResult } from ".."
+import { OperationLimitError } from ".."
+import type { ClientRequest, FollowResponse, StorageResult } from ".."
 import type {
   CommonOperationEvents,
   LimitReached,
@@ -20,45 +21,83 @@ export const createStorageFn = (
     | OperationStorageDone
     | OperationWaitingForContinue
   >,
-) => {
+): FollowResponse["storage"] => {
   const cbStore = createStorageCb(request)
-  return abortablePromiseFn(
-    <Type extends StorageItemInput["type"]>(
-      resolve: (value: StorageResult<Type>) => void,
-      reject: (e: Error) => void,
-      hash: string,
-      type: Type,
-      key: string,
-      childTrie: string | null,
-    ) => {
-      const isDescendants = type.startsWith("descendants")
-      let result: any = isDescendants ? [] : null
+  return abortablePromiseFn((resolve, reject, hash, type, key, childTrie) => {
+    const result: {
+      value: StorageResult<"value">
+      hash: StorageResult<"hash">
+      closestDescendantMerkleValue: StorageResult<"closestDescendantMerkleValue">
+      descendantsValues: StorageResult<"descendantsValues">
+      descendantsHashes: StorageResult<"descendantsHashes">
+    } = {
+      value: null,
+      hash: null,
+      closestDescendantMerkleValue: null,
+      descendantsValues: [],
+      descendantsHashes: [],
+    }
+    const onItems = (items: StorageItemResponse[]) => {
+      if (isDescendantsValues(type)) {
+        result[type].push(...(items as Array<{ key: string; value: string }>))
+      }
+      if (isDescendantsHashes(type)) {
+        result[type].push(...(items as Array<{ key: string; hash: string }>))
+      }
+      if (
+        isValue(type) ||
+        isHash(type) ||
+        isClosestDescendantMerkleValue(type)
+      ) {
+        result[type] = items[0]?.[type] ?? null
+      }
+    }
 
-      const onItems = isDescendants
-        ? (items: StorageItemResponse[]) => {
-            result.push(...items)
-          }
-        : (items: StorageItemResponse[]) => {
-            result = items[0]?.[type as "value"]
-          }
+    const cancel = cbStore(
+      hash,
+      [{ key, type }],
+      childTrie,
+      onItems,
+      reject,
+      () => resolve(result[type] as StorageResult<typeof type>),
+      (nDiscarded) => {
+        if (nDiscarded > 0) {
+          cancel()
+          reject(new OperationLimitError())
+        }
+      },
+    )
 
-      const cancel = cbStore(
-        hash,
-        [{ key, type }],
-        childTrie ?? null,
-        onItems,
-        reject,
-        () => {
-          resolve(result)
-        },
-        (nDiscarded) => {
-          if (nDiscarded > 0) {
-            cancel()
-            reject(new OperationLimitError())
-          }
-        },
-      )
-      return cancel
-    },
-  )
+    return cancel
+  })
+}
+
+function isValue<T extends StorageItemInput["type"]>(
+  type: T,
+): type is Extract<T, "value"> {
+  return type === "value"
+}
+
+function isHash<T extends StorageItemInput["type"]>(
+  type: T,
+): type is Extract<T, "hash"> {
+  return type === "hash"
+}
+
+function isClosestDescendantMerkleValue<T extends StorageItemInput["type"]>(
+  type: T,
+): type is Extract<T, "closestDescendantMerkleValue"> {
+  return type === "closestDescendantMerkleValue"
+}
+
+function isDescendantsValues<T extends StorageItemInput["type"]>(
+  type: T,
+): type is Extract<T, "descendantsValues"> {
+  return type === "descendantsValues"
+}
+
+function isDescendantsHashes<T extends StorageItemInput["type"]>(
+  type: T,
+): type is Extract<T, "descendantsHashes"> {
+  return type === "descendantsHashes"
 }


### PR DESCRIPTION
I added this test to just check the types. Since we were casting as `any` we leaked the `undefined` type but the signature of the promise is

![image](https://github.com/paritytech/polkadot-api/assets/21375952/d475a0b1-50c2-4755-99f0-be37830efd63)

```ts
import { describe, expect, test } from "vitest"
import { setupChainHeadOperationSubscription } from "./fixtures"

describe("storage", () => {
  test("yolo", async () => {
    const blockHash =
      "0x41532ba0356516a8a87bc1791ca0dacbae6adf2bf5479531b04f946aa690a7f0"
    const a =
      "0x326f43b5d5c73340a7cf6d7d9c539b08b841fa455eb8ed03513e13044d5c237a"
    const {
      fixtures: { sendOperationNotification },
      operationPromise,
    } = setupChainHeadOperationSubscription(
      { name: "storage", discardedItems: 0 },
      blockHash,
      "hash",
      a,
      null,
    )

    const items: any[] = []

    sendOperationNotification({
      type: "operationStorageItems",
      items,
    })
    sendOperationNotification({
      type: "operationStorageDone",
    })

    await expect(operationPromise).resolves.not.toStrictEqual(undefined)
  })
})


```