### PR TITLE
fix(cli): save descriptors output codegen

### DIFF
--- a/packages/cli/src/data.ts
+++ b/packages/cli/src/data.ts
@@ -52,8 +52,13 @@ export class Data {
     message: string,
     items: [string, bigint][],
   ) {
-    this.descriptorData[pallet] = this.descriptorData[pallet] ?? {}
-    this.descriptorData[pallet][type] = this.descriptorData[pallet][type] ?? {}
+    this.descriptorData[pallet] = this.descriptorData[pallet] ?? {
+      constants: {},
+      storage: {},
+      events: {},
+      errors: {},
+      extrinsics: {},
+    }
     const data = this.descriptorData[pallet][type]
 
     const selected = await checkbox({

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -294,6 +294,7 @@ while (!exit) {
         })
       }
 
+      await outputCodegen(data, outputFolder, options.key)
       break
     }
     case SYNC: {


### PR DESCRIPTION
fixes a bug where "Save descriptors" in interactive mode wasn't outputting codegen