### PR TITLE
@polkadot-api/tx-helper

### DIFF
--- a/experiments/package.json
+++ b/experiments/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "start": "tsup-node src/main.ts --watch --clean --format esm --platform node --onSuccess \"node --enable-source-maps dist/main.js\"",
     "nominators": "tsup-node src/all-nominators.ts --watch --clean --format esm --platform node --onSuccess \"node --enable-source-maps dist/all-nominators.js\"",
+    "tx": "tsup-node src/tx.ts --watch --clean --format esm --platform node --onSuccess \"node --enable-source-maps dist/tx.js\"",
     "client": "tsup-node src/client.ts --watch --clean --format esm --platform node --onSuccess \"node --enable-source-maps dist/client.js\""
   },
   "keywords": [],
@@ -18,13 +19,16 @@
     "prettier": "^2.6.2"
   },
   "dependencies": {
+    "@noble/curves": "^1.2.0",
     "@polkadot-api/cli": "workspace:*",
+    "@polkadot-api/client": "workspace:*",
     "@polkadot-api/sc-provider": "workspace:*",
     "@polkadot-api/substrate-bindings": "workspace:*",
     "@polkadot-api/substrate-client": "workspace:*",
     "@polkadot-api/substrate-codegen": "workspace:*",
+    "@polkadot-api/tx-helper": "workspace:*",
     "@polkadot-api/utils": "workspace:*",
-    "@polkadot-api/client": "workspace:*"
+    "rxjs": "^7.8.1"
   },
   "prettier": {
     "printWidth": 80,

--- a/experiments/src/tx.ts
+++ b/experiments/src/tx.ts
@@ -1,0 +1,85 @@
+import { UserSignedExtensions, getTxCreator } from "@polkadot-api/tx-helper"
+import { ScProvider, WellKnownChain } from "@polkadot-api/sc-provider"
+import {
+  AccountId,
+  Enum,
+  SS58String,
+  Struct,
+  compact,
+  u8,
+} from "@polkadot-api/substrate-bindings"
+import { fromHex, toHex } from "@polkadot-api/utils"
+import { ed25519 } from "@noble/curves/ed25519"
+import { createClient } from "@polkadot-api/substrate-client"
+
+const client = createClient(ScProvider(WellKnownChain.westend2))
+const priv = fromHex(
+  "0xb18290bac66576e4067e0c47eb23b2eb40dc2a5906fe9af94063dc163367a1f0",
+)
+const from = ed25519.getPublicKey(priv)
+
+const { createTx } = getTxCreator(
+  ScProvider(WellKnownChain.westend2),
+  ({ userSingedExtensionsName }, callback) => {
+    const userSignedExtensionsData = Object.fromEntries(
+      userSingedExtensionsName.map((x) => {
+        if (x === "CheckMortality") {
+          const result: UserSignedExtensions["CheckMortality"] = {
+            mortal: false,
+            // period: 128,
+          }
+          return [x, result]
+        }
+
+        if (x === "ChargeTransactionPayment") return [x, 0n]
+        return [x, { tip: 0n }]
+      }),
+    )
+
+    callback({
+      userSignedExtensionsData,
+      overrides: {},
+      signingType: "Ed25519",
+      signer: async (value) => ed25519.sign(value, priv),
+    })
+  },
+)
+
+const call = Struct({
+  module: u8,
+  method: u8,
+  args: Struct({
+    dest: Enum({
+      Id: AccountId(42),
+    }),
+    value: compact,
+  }),
+})
+
+const transaction = toHex(
+  await createTx(
+    from,
+    call.enc({
+      module: 4,
+      method: 0,
+      args: {
+        dest: {
+          tag: "Id",
+          value:
+            "5DyTf5gsCQG3ycM1venTzjoEPMUhKtoU9e9zg1MvnJddbye8" as SS58String,
+        },
+        value: 1000000n,
+      },
+    }),
+  ),
+)
+
+client.transaction(
+  transaction,
+  (e) => {
+    console.log(e)
+  },
+  (e) => {
+    console.error("there was an error ", e)
+  },
+)

--- a/packages/tx-helper/README.md
+++ b/packages/tx-helper/README.md
@@ -1,0 +1,1 @@
+# @polkadot-api/tx-helper

--- a/packages/tx-helper/package.json
+++ b/packages/tx-helper/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@polkadot-api/tx-helper",
+  "version": "0.0.0",
+  "author": "Josep M Sobrepere (https://github.com/josepot)",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/paritytech/polkadot-api.git"
+  },
+  "license": "MIT",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "node": {
+        "production": {
+          "import": "./dist/index.mjs",
+          "require": "./dist/min/index.js",
+          "default": "./dist/index.js"
+        },
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "module": "./dist/index.mjs",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "browser": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --noEmit && tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2020 --format esm,cjs --dts && tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2020 --format cjs --dts --minify --out-dir dist/min",
+    "test": "echo 'no tests'",
+    "lint": "tsc --noEmit && prettier --check README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
+    "format": "prettier --write README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
+    "prepack": "pnpm run build"
+  },
+  "prettier": {
+    "printWidth": 80,
+    "semi": false,
+    "trailingComma": "all"
+  },
+  "dependencies": {
+    "@noble/hashes": "^1.3.1",
+    "@polkadot-api/client": "workspace:*",
+    "@polkadot-api/json-rpc-provider": "workspace:*",
+    "@polkadot-api/sc-provider": "workspace:*",
+    "@polkadot-api/substrate-bindings": "workspace:*",
+    "@polkadot-api/substrate-client": "workspace:*",
+    "@polkadot-api/substrate-codegen": "workspace:*",
+    "@polkadot-api/utils": "workspace:*",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^0.34.3"
+  }
+}

--- a/packages/tx-helper/src/get-tx-creator/get-relevant-signed-extensions.ts
+++ b/packages/tx-helper/src/get-tx-creator/get-relevant-signed-extensions.ts
@@ -28,7 +28,7 @@ export const getRelevantSignedExtensions = (metadata: V14) => {
 
   const user: Array<UserSignedExtensionName> = []
   const chain: Array<"CheckGenesis" | "CheckNonce" | "CheckSpecVersion"> = []
-  const unkown: Array<string> = []
+  const unknown: Array<string> = []
 
   const all: Array<string> = relevant.map((x) => x.identifier)
 
@@ -37,8 +37,8 @@ export const getRelevantSignedExtensions = (metadata: V14) => {
       chain.push(sExtension as any)
     else if (userSignedExtensions[sExtension as "CheckMortality"])
       user.push(sExtension as any)
-    else unkown.push(sExtension)
+    else unknown.push(sExtension)
   })
 
-  return { all, user, chain, unkown }
+  return { all, user, chain, unknown }
 }

--- a/packages/tx-helper/src/get-tx-creator/get-relevant-signed-extensions.ts
+++ b/packages/tx-helper/src/get-tx-creator/get-relevant-signed-extensions.ts
@@ -1,0 +1,44 @@
+import { V14, _void } from "@polkadot-api/substrate-bindings"
+import {
+  getChecksumBuilder,
+  getDynamicBuilder,
+} from "@polkadot-api/substrate-codegen"
+import {
+  chainSignedExtensions,
+  userSignedExtensions,
+} from "@/signed-extensions"
+import type { UserSignedExtensionName } from "@/."
+
+export const getRelevantSignedExtensions = (metadata: V14) => {
+  const checksumBuilder = getChecksumBuilder(metadata)
+  const dynamicBuilder = getDynamicBuilder(metadata)
+
+  const getDefinition = (type: number) => ({
+    codec: dynamicBuilder.buildDefinition(type),
+    checksum: checksumBuilder.buildDefinition(type),
+  })
+
+  const relevant = metadata.extrinsic.signedExtensions
+    .map(({ identifier, type, additionalSigned }) => ({
+      identifier,
+      type: getDefinition(type),
+      additionalSigned: getDefinition(additionalSigned),
+    }))
+    .filter((v) => v.type.codec !== _void || v.additionalSigned.codec !== _void)
+
+  const user: Array<UserSignedExtensionName> = []
+  const chain: Array<"CheckGenesis" | "CheckNonce" | "CheckSpecVersion"> = []
+  const unkown: Array<string> = []
+
+  const all: Array<string> = relevant.map((x) => x.identifier)
+
+  all.forEach((sExtension) => {
+    if (chainSignedExtensions[sExtension as "CheckGenesis"])
+      chain.push(sExtension as any)
+    else if (userSignedExtensions[sExtension as "CheckMortality"])
+      user.push(sExtension as any)
+    else unkown.push(sExtension)
+  })
+
+  return { all, user, chain, unkown }
+}

--- a/packages/tx-helper/src/get-tx-creator/get-tx-creator.ts
+++ b/packages/tx-helper/src/get-tx-creator/get-tx-creator.ts
@@ -1,0 +1,60 @@
+import { blake2b } from "@noble/hashes/blake2b"
+import { createClient } from "@polkadot-api/substrate-client"
+import { getObservableClient } from "@polkadot-api/client"
+import {
+  filter,
+  firstValueFrom,
+  map,
+  mergeMap,
+  take,
+  withLatestFrom,
+} from "rxjs"
+import { _void, compact } from "@polkadot-api/substrate-bindings"
+import { mergeUint8 } from "@polkadot-api/utils"
+
+import type { CreateTx, GetTxCreator } from "@/."
+import { getRelevantSignedExtensions } from "./get-relevant-signed-extensions"
+import { multiAddressEncoder } from "./multi-address-encoder"
+import { signatureEncoder } from "./signature-encoder"
+import { getTxData } from "./get-tx-data"
+import { versionBytes } from "./version-bytes"
+
+export const getTxCreator: GetTxCreator = (chainProvider, onCreateTx) => {
+  const client = getObservableClient(createClient(chainProvider))
+  const chainHead = client.chainHead$()
+  const metaCtx$ = chainHead.metadata$.pipe(
+    filter(Boolean),
+    withLatestFrom(chainHead.finalized$),
+    take(1),
+    map(([metadata, at]) => {
+      const signedExtensions = getRelevantSignedExtensions(metadata)
+      return { metadata, at, signedExtensions }
+    }),
+  )
+
+  const createTx: CreateTx = async (from, callData) => {
+    const { signer, extra, additional } = await firstValueFrom(
+      metaCtx$.pipe(mergeMap(getTxData(from, callData, chainHead, onCreateTx))),
+    )
+
+    const toSign = mergeUint8(callData, extra, additional)
+    const signed = await signer.signer(
+      toSign.length > 256 ? blake2b(toSign) : toSign,
+    )
+
+    const preResult = mergeUint8(
+      versionBytes,
+      multiAddressEncoder(from),
+      signatureEncoder({ tag: signer.signingType, value: signed }),
+      extra,
+      callData,
+    )
+    return mergeUint8(compact.enc(preResult.length), preResult)
+  }
+
+  const destroy = () => {
+    chainHead.unfollow()
+  }
+
+  return { createTx, destroy }
+}

--- a/packages/tx-helper/src/get-tx-creator/get-tx-data.ts
+++ b/packages/tx-helper/src/get-tx-creator/get-tx-data.ts
@@ -1,0 +1,125 @@
+import { V14, v14 } from "@polkadot-api/substrate-bindings"
+import { ConsumerCallback, OnCreateTxCtx, UserSignedExtensionName } from ".."
+import { getInput$ } from "./input"
+import {
+  EMPTY,
+  NEVER,
+  Observable,
+  combineLatest,
+  map,
+  mergeMap,
+  of,
+  race,
+} from "rxjs"
+import type { SignedExntension } from "@/internal-types"
+import { getObservableClient } from "@polkadot-api/client"
+import { mergeUint8 } from "@polkadot-api/utils"
+import {
+  chainSignedExtensions,
+  userSignedExtensions,
+} from "@/signed-extensions"
+
+interface Ctx {
+  metadata: V14
+  at: string
+  signedExtensions: {
+    all: string[]
+    user: Array<UserSignedExtensionName>
+    chain: Array<"CheckGenesis" | "CheckNonce" | "CheckSpecVersion">
+    unkown: string[]
+  }
+}
+
+export const getTxData =
+  <T extends Array<UserSignedExtensionName>>(
+    from: Uint8Array,
+    callData: Uint8Array,
+    chainHead: ReturnType<ReturnType<typeof getObservableClient>["chainHead$"]>,
+    onCreateTx: (
+      context: OnCreateTxCtx<T>,
+      callback: (value: null | ConsumerCallback<T>) => void,
+    ) => void,
+  ) =>
+  ({ metadata, at, signedExtensions }: Ctx) => {
+    const { all, user, chain, unkown } = signedExtensions
+    const { overrides$, getUserInput$, signer$ } = getInput$<T>(
+      {
+        from,
+        callData,
+        metadata: v14.enc(metadata),
+        userSingedExtensionsName: user as any,
+        unknownSignedExtensions: unkown,
+      },
+      onCreateTx,
+    )
+
+    const fromOverrides = (
+      name: string,
+      type: "value" | "additionalSigned",
+      endless: boolean,
+    ) =>
+      overrides$.pipe(
+        mergeMap((overrides) =>
+          overrides[name] ? of(overrides[name][type]) : endless ? NEVER : EMPTY,
+        ),
+      )
+
+    const withOverrides = (
+      { additional, extra }: SignedExntension,
+      name: string,
+    ): SignedExntension => ({
+      additional: race([fromOverrides(name, "value", true), additional]),
+      extra: race([fromOverrides(name, "additionalSigned", true), extra]),
+    })
+
+    const extra: Array<Observable<Uint8Array>> = []
+    const additional: Array<Observable<Uint8Array>> = []
+
+    const chainSet = new Set(chain)
+    const userSet = new Set(user)
+    const ctx = {
+      from,
+      callData,
+      metadata,
+      at,
+      chainHead,
+    }
+
+    all
+      .map((key) => {
+        if (chainSet.has(key as any))
+          return withOverrides(
+            chainSignedExtensions[key as "CheckNonce"](ctx),
+            key,
+          )
+
+        if (userSet.has(key as any))
+          return withOverrides(
+            userSignedExtensions[key as "CheckMortality"](
+              getUserInput$(key as "CheckMortality") as any,
+              ctx,
+            ),
+            key,
+          )
+
+        return {
+          extra: fromOverrides(key, "value", false),
+          additional: fromOverrides(key, "additionalSigned", false),
+        }
+      })
+      .forEach((value) => {
+        additional.push(value.additional)
+        extra.push(value.extra)
+      })
+
+    const extra$ = combineLatest(extra).pipe(map((x) => mergeUint8(...x)))
+    const additional$ = combineLatest(additional).pipe(
+      map((x) => mergeUint8(...x)),
+    )
+
+    return combineLatest({
+      signer: signer$,
+      extra: extra$,
+      additional: additional$,
+    })
+  }

--- a/packages/tx-helper/src/get-tx-creator/get-tx-data.ts
+++ b/packages/tx-helper/src/get-tx-creator/get-tx-data.ts
@@ -11,7 +11,7 @@ import {
   of,
   race,
 } from "rxjs"
-import type { SignedExntension } from "@/internal-types"
+import type { SignedExtension } from "@/internal-types"
 import { getObservableClient } from "@polkadot-api/client"
 import { mergeUint8 } from "@polkadot-api/utils"
 import {
@@ -26,7 +26,7 @@ interface Ctx {
     all: string[]
     user: Array<UserSignedExtensionName>
     chain: Array<"CheckGenesis" | "CheckNonce" | "CheckSpecVersion">
-    unkown: string[]
+    unknown: string[]
   }
 }
 
@@ -41,14 +41,14 @@ export const getTxData =
     ) => void,
   ) =>
   ({ metadata, at, signedExtensions }: Ctx) => {
-    const { all, user, chain, unkown } = signedExtensions
+    const { all, user, chain, unknown } = signedExtensions
     const { overrides$, getUserInput$, signer$ } = getInput$<T>(
       {
         from,
         callData,
         metadata: v14.enc(metadata),
         userSingedExtensionsName: user as any,
-        unknownSignedExtensions: unkown,
+        unknownSignedExtensions: unknown,
       },
       onCreateTx,
     )
@@ -65,9 +65,9 @@ export const getTxData =
       )
 
     const withOverrides = (
-      { additional, extra }: SignedExntension,
+      { additional, extra }: SignedExtension,
       name: string,
-    ): SignedExntension => ({
+    ): SignedExtension => ({
       additional: race([fromOverrides(name, "value", true), additional]),
       extra: race([fromOverrides(name, "additionalSigned", true), extra]),
     })

--- a/packages/tx-helper/src/get-tx-creator/index.ts
+++ b/packages/tx-helper/src/get-tx-creator/index.ts
@@ -1,0 +1,1 @@
+export * from "./get-tx-creator"

--- a/packages/tx-helper/src/get-tx-creator/input.ts
+++ b/packages/tx-helper/src/get-tx-creator/input.ts
@@ -1,0 +1,85 @@
+import {
+  ConsumerCallback,
+  OnCreateTxCtx,
+  UserSignedExtensionName,
+  Callback,
+} from "@/types"
+import { Observable, filter, map, noop, share } from "rxjs"
+
+export const getInput$ = <T extends Array<UserSignedExtensionName>>(
+  ctx: OnCreateTxCtx<T>,
+  onCreateTx: (
+    context: OnCreateTxCtx<T>,
+    callback: Callback<null | ConsumerCallback<T>>,
+  ) => void,
+) => {
+  const { userSingedExtensionsName: user, unknownSignedExtensions: unkown } =
+    ctx
+
+  const input$ = new Observable<ConsumerCallback<T>>((observer) => {
+    let onInput: Callback<null | ConsumerCallback<T>> = (x) => {
+      if (!x) return observer.error(new Error("User cancelled tx"))
+
+      const userKeys = user
+      for (let i = 0; i < userKeys.length; i++) {
+        const userKey = userKeys[i]
+        if (Object.hasOwn(x.userSignedExtensionsData as any, userKey)) continue
+
+        if (!x.overrides[userKey])
+          return observer.error(new Error(`Missing user data for "${userKey}"`))
+      }
+
+      const missingUnknown = unkown.filter((uKey) => !x.overrides[uKey])
+
+      if (missingUnknown.length) {
+        return observer.error(
+          new Error(
+            `Missing signed-extensions: "${missingUnknown.join(", ")}"`,
+          ),
+        )
+      }
+
+      observer.next(x)
+      observer.complete()
+    }
+
+    onCreateTx(ctx, (x) => {
+      Promise.resolve().then(() => {
+        onInput(x as any)
+      })
+    })
+
+    return () => {
+      onInput = noop
+    }
+  }).pipe(share())
+
+  const getUserInput$ = (key: UserSignedExtensionName) =>
+    input$.pipe(
+      map(
+        ({ userSignedExtensionsData }) =>
+          (userSignedExtensionsData as any)[key],
+      ),
+      filter((x) => x !== undefined),
+    )
+
+  const overrides$: Observable<
+    Record<
+      string,
+      {
+        value: Uint8Array
+        additionalSigned: Uint8Array
+      }
+    >
+  > = input$.pipe(map(({ overrides }) => overrides))
+
+  const signer$ = input$.pipe(
+    map(({ signer, signingType }) => ({ signer, signingType })),
+  )
+
+  return {
+    getUserInput$,
+    overrides$,
+    signer$,
+  }
+}

--- a/packages/tx-helper/src/get-tx-creator/input.ts
+++ b/packages/tx-helper/src/get-tx-creator/input.ts
@@ -13,7 +13,7 @@ export const getInput$ = <T extends Array<UserSignedExtensionName>>(
     callback: Callback<null | ConsumerCallback<T>>,
   ) => void,
 ) => {
-  const { userSingedExtensionsName: user, unknownSignedExtensions: unkown } =
+  const { userSingedExtensionsName: user, unknownSignedExtensions: unknown } =
     ctx
 
   const input$ = new Observable<ConsumerCallback<T>>((observer) => {
@@ -29,7 +29,7 @@ export const getInput$ = <T extends Array<UserSignedExtensionName>>(
           return observer.error(new Error(`Missing user data for "${userKey}"`))
       }
 
-      const missingUnknown = unkown.filter((uKey) => !x.overrides[uKey])
+      const missingUnknown = unknown.filter((uKey) => !x.overrides[uKey])
 
       if (missingUnknown.length) {
         return observer.error(

--- a/packages/tx-helper/src/get-tx-creator/multi-address-encoder.ts
+++ b/packages/tx-helper/src/get-tx-creator/multi-address-encoder.ts
@@ -1,0 +1,5 @@
+import { Encoder } from "@polkadot-api/substrate-bindings"
+
+export const multiAddressEncoder: Encoder<Uint8Array> = (input) =>
+  // converting it to a `MultiAddress` enum, where the index 0 is `Id(AccountId)`
+  new Uint8Array([0, ...input])

--- a/packages/tx-helper/src/get-tx-creator/signature-encoder.ts
+++ b/packages/tx-helper/src/get-tx-creator/signature-encoder.ts
@@ -1,0 +1,7 @@
+import { Bytes, Enum } from "@polkadot-api/substrate-bindings"
+
+export const signatureEncoder = Enum({
+  Ed25519: Bytes(64),
+  Sr25519: Bytes(64),
+  Ecdsa: Bytes(65),
+}).enc

--- a/packages/tx-helper/src/get-tx-creator/version-bytes.ts
+++ b/packages/tx-helper/src/get-tx-creator/version-bytes.ts
@@ -1,0 +1,9 @@
+import { enhanceEncoder, u8 } from "@polkadot-api/substrate-bindings"
+
+const versionCodec = enhanceEncoder(
+  u8.enc,
+  (value: { signed: boolean; version: number }) =>
+    (+!!value.signed << 7) | value.version,
+)
+
+export const versionBytes = versionCodec({ signed: true, version: 4 })

--- a/packages/tx-helper/src/index.ts
+++ b/packages/tx-helper/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./types"
+export * from "./get-tx-creator"

--- a/packages/tx-helper/src/internal-types.ts
+++ b/packages/tx-helper/src/internal-types.ts
@@ -11,14 +11,14 @@ export interface ChainExtensionCtx {
   chainHead: ReturnType<ReturnType<typeof getObservableClient>["chainHead$"]>
 }
 
-export interface SignedExntension {
+export interface SignedExtension {
   extra: Observable<Uint8Array>
   additional: Observable<Uint8Array>
 }
 
 export type GetChainSignedExtension = (
   ctx: ChainExtensionCtx,
-) => SignedExntension
+) => SignedExtension
 
 export type GetUserSignedExtension<K extends UserSignedExtensionName> = (
   input$: Observable<UserSignedExtensionsInput<K>>,

--- a/packages/tx-helper/src/internal-types.ts
+++ b/packages/tx-helper/src/internal-types.ts
@@ -1,0 +1,29 @@
+import { V14 } from "@polkadot-api/substrate-bindings"
+import { UserSignedExtensionName, UserSignedExtensionsInput } from "./types"
+import { getObservableClient } from "@polkadot-api/client"
+import { Observable } from "rxjs"
+
+export interface ChainExtensionCtx {
+  from: Uint8Array
+  callData: Uint8Array
+  metadata: V14
+  at: string
+  chainHead: ReturnType<ReturnType<typeof getObservableClient>["chainHead$"]>
+}
+
+export interface SignedExntension {
+  extra: Observable<Uint8Array>
+  additional: Observable<Uint8Array>
+}
+
+export type GetChainSignedExtension = (
+  ctx: ChainExtensionCtx,
+) => SignedExntension
+
+export type GetUserSignedExtension<K extends UserSignedExtensionName> = (
+  input$: Observable<UserSignedExtensionsInput<K>>,
+  ctx: ChainExtensionCtx,
+) => {
+  extra: Observable<Uint8Array>
+  additional: Observable<Uint8Array>
+}

--- a/packages/tx-helper/src/signed-extensions/chain/CheckGenesis.ts
+++ b/packages/tx-helper/src/signed-extensions/chain/CheckGenesis.ts
@@ -1,0 +1,7 @@
+import type { GetChainSignedExtension } from "@/internal-types"
+import { empty$, genesisHashFromCtx } from "../utils"
+
+export const CheckGenesis: GetChainSignedExtension = (ctx) => ({
+  additional: genesisHashFromCtx(ctx),
+  extra: empty$,
+})

--- a/packages/tx-helper/src/signed-extensions/chain/CheckNonce.ts
+++ b/packages/tx-helper/src/signed-extensions/chain/CheckNonce.ts
@@ -1,0 +1,26 @@
+import { map } from "rxjs"
+import { compact, u16, u32, u64 } from "@polkadot-api/substrate-bindings"
+import type { GetChainSignedExtension } from "@/internal-types"
+import { empty$ } from "../utils"
+import { fromHex, toHex } from "@polkadot-api/utils"
+
+const lenToDecoder = {
+  2: u16.dec,
+  4: u32.dec,
+  8: u64.dec,
+}
+
+export const CheckNonce: GetChainSignedExtension = (ctx) => ({
+  extra: ctx.chainHead
+    .call$(ctx.at, "AccountNonceApi_account_nonce", toHex(ctx.from))
+    .pipe(
+      map((result) => {
+        const bytes = fromHex(result)
+        const decoder = lenToDecoder[bytes.length as 2 | 4 | 8]
+        if (!decoder)
+          throw new Error("AccountNonceApi_account_nonce retrieved wrong data")
+        return compact.enc(decoder(bytes))
+      }),
+    ),
+  additional: empty$,
+})

--- a/packages/tx-helper/src/signed-extensions/chain/CheckSpecVersion.ts
+++ b/packages/tx-helper/src/signed-extensions/chain/CheckSpecVersion.ts
@@ -1,0 +1,7 @@
+import type { GetChainSignedExtension } from "@/internal-types"
+import { empty$, systemVersionProp$ } from "../utils"
+
+export const CheckSpecVersion: GetChainSignedExtension = ({ metadata }) => ({
+  additional: systemVersionProp$("spec_version", metadata),
+  extra: empty$,
+})

--- a/packages/tx-helper/src/signed-extensions/chain/CheckTxVersion.ts
+++ b/packages/tx-helper/src/signed-extensions/chain/CheckTxVersion.ts
@@ -1,0 +1,7 @@
+import type { GetChainSignedExtension } from "@/internal-types"
+import { empty$, systemVersionProp$ } from "../utils"
+
+export const CheckTxVersion: GetChainSignedExtension = ({ metadata }) => ({
+  additional: systemVersionProp$("transaction_version", metadata),
+  extra: empty$,
+})

--- a/packages/tx-helper/src/signed-extensions/chain/index.ts
+++ b/packages/tx-helper/src/signed-extensions/chain/index.ts
@@ -1,0 +1,4 @@
+export * from "./CheckGenesis"
+export * from "./CheckNonce"
+export * from "./CheckSpecVersion"
+export * from "./CheckTxVersion"

--- a/packages/tx-helper/src/signed-extensions/index.ts
+++ b/packages/tx-helper/src/signed-extensions/index.ts
@@ -1,0 +1,2 @@
+export * as chainSignedExtensions from "./chain"
+export * as userSignedExtensions from "./user"

--- a/packages/tx-helper/src/signed-extensions/user/ChargeAssetTxPayment.ts
+++ b/packages/tx-helper/src/signed-extensions/user/ChargeAssetTxPayment.ts
@@ -1,0 +1,16 @@
+import { map } from "rxjs"
+import { Option, Struct, compact, u32 } from "@polkadot-api/substrate-bindings"
+import type { GetUserSignedExtension } from "@/internal-types"
+import { empty$ } from "../utils"
+
+const encoder = Struct({
+  tip: compact,
+  assetId: Option(u32),
+}).enc
+
+export const ChargeAssetTxPayment: GetUserSignedExtension<
+  "ChargeAssetTxPayment"
+> = (user$) => ({
+  extra: user$.pipe(map(encoder)),
+  additional: empty$,
+})

--- a/packages/tx-helper/src/signed-extensions/user/ChargeTransactionPayment.ts
+++ b/packages/tx-helper/src/signed-extensions/user/ChargeTransactionPayment.ts
@@ -1,0 +1,11 @@
+import { compactBn } from "@polkadot-api/substrate-bindings"
+import { map } from "rxjs"
+import type { GetUserSignedExtension } from "@/internal-types"
+import { empty$ } from "../utils"
+
+export const ChargeTransactionPayment: GetUserSignedExtension<
+  "ChargeTransactionPayment"
+> = (user$) => ({
+  extra: user$.pipe(map(compactBn.enc)),
+  additional: empty$,
+})

--- a/packages/tx-helper/src/signed-extensions/user/CheckMortality.ts
+++ b/packages/tx-helper/src/signed-extensions/user/CheckMortality.ts
@@ -1,0 +1,61 @@
+import { combineLatest, map, mergeMap, of } from "rxjs"
+import {
+  Bytes,
+  Storage,
+  enhanceEncoder,
+  u16,
+  u32,
+  u8,
+} from "@polkadot-api/substrate-bindings"
+import { fromHex } from "@polkadot-api/utils"
+import type { GetUserSignedExtension } from "@/internal-types"
+import { genesisHashFromCtx } from "../utils"
+
+function trailingZeroes(n: number) {
+  let i = 0
+  while (!(n & 1)) {
+    i++
+    n >>= 1
+  }
+  return i
+}
+
+const mortal = enhanceEncoder(
+  Bytes(2).enc,
+  (value: { period: number; phase: number }) => {
+    const factor = Math.max(value.period >> 12, 1)
+    const left = Math.min(Math.max(trailingZeroes(value.period) - 1, 1), 15)
+    const right = (value.phase / factor) << 4
+    return u16.enc(left | right)
+  },
+)
+
+const SystemNumber = Storage("System")("Number", u32.dec)
+const SystemNumberKey = SystemNumber.enc()
+
+export const CheckMortality: GetUserSignedExtension<"CheckMortality"> = (
+  userInput$,
+  ctx,
+) => {
+  const blockNumber$ = ctx.chainHead
+    .storage$(ctx.at, "value", SystemNumberKey, null)
+    .pipe(map((x) => SystemNumber.dec(x!)))
+
+  return {
+    additional: userInput$.pipe(
+      mergeMap((input) =>
+        input.mortal ? of(fromHex(ctx.at)) : genesisHashFromCtx(ctx),
+      ),
+    ),
+    extra: combineLatest([userInput$, blockNumber$]).pipe(
+      map(([input, blockNumber]) =>
+        input.mortal
+          ? mortal({
+              period: input.period,
+              phase: blockNumber % input.period,
+            })
+          : u8.enc(0),
+      ),
+    ),
+  }
+}

--- a/packages/tx-helper/src/signed-extensions/user/index.ts
+++ b/packages/tx-helper/src/signed-extensions/user/index.ts
@@ -1,0 +1,3 @@
+export * from "./ChargeTransactionPayment"
+export * from "./CheckMortality"
+export * from "./ChargeAssetTxPayment"

--- a/packages/tx-helper/src/signed-extensions/utils.ts
+++ b/packages/tx-helper/src/signed-extensions/utils.ts
@@ -1,0 +1,42 @@
+import { map, noop, of } from "rxjs"
+import {
+  V14,
+  Storage,
+  Twox64Concat,
+  u32,
+} from "@polkadot-api/substrate-bindings"
+import { getDynamicBuilder, getLookupFn } from "@polkadot-api/substrate-codegen"
+import { fromHex } from "@polkadot-api/utils"
+import type { ChainExtensionCtx } from "@/internal-types"
+
+export const empty$ = of(new Uint8Array())
+
+const genesisHashStorageKey = Storage("System")("BlockHash", noop, [
+  u32,
+  Twox64Concat,
+]).enc(0)
+
+export const genesisHashFromCtx = (ctx: ChainExtensionCtx) =>
+  ctx.chainHead
+    .storage$(ctx.at, "value", genesisHashStorageKey, null)
+    .pipe(map((result) => fromHex(result!)))
+
+export const systemVersionProp$ = (propName: string, metadata: V14) => {
+  const lookupFn = getLookupFn(metadata.lookup)
+  const dynamicBuilder = getDynamicBuilder(metadata)
+
+  const constant = metadata.pallets
+    .find((x) => x.name === "System")!
+    .constants!.find((s) => s.name === "Version")!
+
+  const systemVersion = lookupFn(constant.type)
+  const systemVersionDec = dynamicBuilder.buildDefinition(constant.type).dec
+
+  if (systemVersion.type !== "struct") throw new Error("not a struct")
+
+  const valueEnc = dynamicBuilder.buildDefinition(
+    systemVersion.value[propName].id,
+  ).enc
+
+  return of(valueEnc(systemVersionDec(constant.value)[propName]))
+}

--- a/packages/tx-helper/src/types.ts
+++ b/packages/tx-helper/src/types.ts
@@ -1,0 +1,93 @@
+import type { GetProvider } from "@polkadot-api/json-rpc-provider"
+
+export type Callback<T> = (value: T) => void
+
+export type GetTxCreator = (
+  // The `TransactionCreator` communicates with the Chain to obtain metadata, latest block, nonce, etc.
+  chainProvider: GetProvider,
+
+  // This callback is invoked in order to capture the necessary user input
+  // for creating the transaction.
+  onCreateTx: <UserSignedExtensionsName extends Array<UserSignedExtensionName>>(
+    context: OnCreateTxCtx<UserSignedExtensionsName>,
+
+    // The function to call once the user has decided to cancel or proceed with the tx.
+    // Passing `null` indicates that the user has decided not to sing the tx.
+    callback: Callback<null | ConsumerCallback<UserSignedExtensionsName>>,
+  ) => void,
+) => {
+  createTx: CreateTx
+  destroy: () => void
+}
+
+export type OnCreateTxCtx<
+  UserSignedExtensionsName extends Array<UserSignedExtensionName>,
+> = {
+  // The public-key of the sender
+  from: Uint8Array
+
+  // The scale encoded call-data (module index, call index and args)
+  callData: Uint8Array
+
+  // The list of signed extensions that require from user input.
+  // The user interface should know how to adapt to the possibility that
+  // different chains may require a different set of these.
+  userSingedExtensionsName: UserSignedExtensionsName
+
+  // An Array containing a list of the signed extensions which are unkown
+  // to the library and that require for a value on the "extra" field
+  // and/or additionally signed data. This will give the consumer the opportunity
+  // to provide that data via the `overrides` field of the callback.
+
+  unknownSignedExtensions: Array<string>
+  // The user interface may need the metadata for many different reasons:
+  // knowing how to decode and present the arguments of the call to the user,
+  // validate the user iput, later decode the singer data, etc, etc.
+  metadata: Uint8Array
+}
+
+export type ConsumerCallback<T extends Array<UserSignedExtensionName>> = {
+  // A tuple with the user-data corresponding to the provided `userSignedExtensionsName`
+  userSignedExtensionsData: UserSignedExtensionsData<T>
+
+  // in case that the consumer wants to add some signed-extension overrides
+  overrides: Record<string, { value: Uint8Array; additionalSigned: Uint8Array }>
+
+  // The type of the signature method
+  signingType: SigningType
+
+  // The function that will be called in order to finally sign the signature payload.
+  signer: (input: Uint8Array) => Promise<Uint8Array>
+}
+
+export type CreateTx = (
+  from: Uint8Array, // The public-key of the sender
+  callData: Uint8Array,
+) => Promise<Uint8Array>
+
+export type SigningType = "Ed25519" | "Sr25519" | "Ecdsa"
+
+export type UserSignedExtensions = {
+  CheckMortality: { mortal: false } | { mortal: true; period: number }
+  ChargeTransactionPayment: bigint
+  ChargeAssetTxPayment: { tip: bigint; assetId: number | undefined }
+}
+
+export type UserSignedExtensionName = keyof UserSignedExtensions
+
+export type TupleToIntersection<T extends Array<any>> = T extends [
+  infer V,
+  ...infer Rest,
+]
+  ? V & TupleToIntersection<Rest>
+  : unknown
+
+export type UserSignedExtensionsData<T extends Array<UserSignedExtensionName>> =
+  TupleToIntersection<{
+    [K in keyof T]: T[K] extends UserSignedExtensionName
+      ? Pick<UserSignedExtensions, T[K]>
+      : {}
+  }>
+
+export type UserSignedExtensionsInput<T extends UserSignedExtensionName> =
+  UserSignedExtensions[T]

--- a/packages/tx-helper/src/types.ts
+++ b/packages/tx-helper/src/types.ts
@@ -34,7 +34,7 @@ export type OnCreateTxCtx<
   // different chains may require a different set of these.
   userSingedExtensionsName: UserSignedExtensionsName
 
-  // An Array containing a list of the signed extensions which are unkown
+  // An Array containing a list of the signed extensions which are unknown
   // to the library and that require for a value on the "extra" field
   // and/or additionally signed data. This will give the consumer the opportunity
   // to provide that data via the `overrides` field of the callback.
@@ -42,7 +42,7 @@ export type OnCreateTxCtx<
   unknownSignedExtensions: Array<string>
   // The user interface may need the metadata for many different reasons:
   // knowing how to decode and present the arguments of the call to the user,
-  // validate the user iput, later decode the singer data, etc, etc.
+  // validate the user input, later decode the singer data, etc, etc.
   metadata: Uint8Array
 }
 

--- a/packages/tx-helper/tsconfig.json
+++ b/packages/tx-helper/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base",
+  "include": ["src", "tests"],
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["*"]
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
 
   experiments:
     dependencies:
+      '@noble/curves':
+        specifier: ^1.2.0
+        version: 1.2.0
       '@polkadot-api/cli':
         specifier: workspace:*
         version: link:../packages/cli
@@ -56,9 +59,15 @@ importers:
       '@polkadot-api/substrate-codegen':
         specifier: workspace:*
         version: link:../packages/substrate-codegen
+      '@polkadot-api/tx-helper':
+        specifier: workspace:*
+        version: link:../packages/tx-helper
       '@polkadot-api/utils':
         specifier: workspace:*
         version: link:../packages/utils
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.1
     devDependencies:
       '@types/node':
         specifier: ^20.4.7
@@ -234,6 +243,40 @@ importers:
       '@polkadot-api/substrate-bindings':
         specifier: workspace:*
         version: link:../substrate-bindings
+
+  packages/tx-helper:
+    dependencies:
+      '@noble/hashes':
+        specifier: ^1.3.1
+        version: 1.3.2
+      '@polkadot-api/client':
+        specifier: workspace:*
+        version: link:../client
+      '@polkadot-api/json-rpc-provider':
+        specifier: workspace:*
+        version: link:../json-rpc-provider
+      '@polkadot-api/sc-provider':
+        specifier: workspace:*
+        version: link:../sc-provider
+      '@polkadot-api/substrate-bindings':
+        specifier: workspace:*
+        version: link:../substrate-bindings
+      '@polkadot-api/substrate-client':
+        specifier: workspace:*
+        version: link:../substrate-client
+      '@polkadot-api/substrate-codegen':
+        specifier: workspace:*
+        version: link:../substrate-codegen
+      '@polkadot-api/utils':
+        specifier: workspace:*
+        version: link:../utils
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.1
+    devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^0.34.3
+        version: 0.34.4(vitest@0.34.4)
 
   packages/utils: {}
 
@@ -725,6 +768,12 @@ packages:
   /@juanelas/base64@1.1.2:
     resolution: {integrity: sha512-mr2pfRQpWap0Uq4tlrCgp3W+Yjx1/Bpq4QJsYeAQUh1mExgyQvXz7xUhmYT2HcLLspuAL5dpnos8P2QhaCSXsQ==}
     dev: true
+
+  /@noble/curves@1.2.0:
+    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+    dependencies:
+      '@noble/hashes': 1.3.2
+    dev: false
 
   /@noble/hashes@1.3.2:
     resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}


### PR DESCRIPTION
This PR adds the first working version of the `@polkadot-api/tx-helper` that I already describe in [this blog-post](https://forum.polkadot.network/t/polkadot-provider-api-a-common-interface-for-building-decentralized-applications/4128#polkadot-apitx-helper-12).

Internally this library leverages a bunch of `@polkadot-api/*` libraries. However, it's worth noting that those are internal implementation details that don't leak through its public API.

Please have a look at the new experiment (`tx`) that I've added to demonstrate how the library can be used. I've performed all sorts of tests using that experiment to make sure that things work correctly.

Next steps:
- Integration tests (probably using zombienet)
- Performance optimizations: There are a bunch of requests that could be avoided, some because they could be memoized/cached and in other cases b/c different signed extensions could be trying to make the same requests. Although, most of these perf-optimizations belong into the `observableCient` that's imported from `@polkadot-api/client`.
- Offline signing API: it would be fairly easy to add a new API that would allow the consumer to sign the transactions in a different (offline) environment. While this is technically possible with the current API (the signing function is async), it's not very ergonomic, so we should consider adding a new API for those users.
- Docs