### PR TITLE
fix(cli): descriptor codegen

### DIFF
--- a/packages/cli/src/io.ts
+++ b/packages/cli/src/io.ts
@@ -445,7 +445,7 @@ export type ${constName} = StorageType<typeof ${constName}>
   }
 
   const descriptorVariablesRegexp = new RegExp(
-    /(?<=const)\s(.*(Constant|Storage|Event|Error|Call))\s(?=\=)/g,
+    /(?<=const)\s(.*(Constant|Storage|Event|Error|Call))(?=[\s|:].*\=)/g,
   )
 
   const descriptorVariableNames =

--- a/packages/cli/test/cli.spec.ts
+++ b/packages/cli/test/cli.spec.ts
@@ -24,6 +24,9 @@ describe("cli", () => {
       await expect(
         fsExists(path.join(outputDir, "polkadot.ts")),
       ).resolves.toEqual(true)
+      await expect(
+        fsExists(path.join(outputDir, "polkadot.d.ts")),
+      ).resolves.toEqual(false)
     },
     5 * 60_000,
   )

--- a/packages/cli/test/cli.spec.ts
+++ b/packages/cli/test/cli.spec.ts
@@ -2,32 +2,125 @@ import { describe, test, expect } from "vitest"
 import { runner } from "clet"
 import fsExists from "fs.promises.exists"
 import path from "path"
+import descriptorSchema from "../src/descriptor-schema"
+import {
+  ConstantDescriptor,
+  DescriptorCommon,
+  ErrorDescriptor,
+  EventDescriptor,
+  StorageDescriptor,
+  TxDescriptor,
+} from "@polkadot-api/substrate-bindings"
+import fs from "fs/promises"
+
+type Descriptor =
+  | ConstantDescriptor<DescriptorCommon<string, string>, any>
+  | EventDescriptor<DescriptorCommon<string, string>, any>
+  | StorageDescriptor<DescriptorCommon<string, string>, any>
+  | ErrorDescriptor<DescriptorCommon<string, string>, any>
+  | TxDescriptor<DescriptorCommon<string, string>, any, any, any>
 
 const cmd = "./bin/main.js"
-const outputDir = "artifacts/descriptors"
 
-describe("cli", () => {
-  test(
-    "descriptor codegen",
-    async () => {
-      await runner()
-        .file("package.json", { bin: { "polkadot-api": cmd } })
-        .file("test_descriptors.json", {
-          polkadot: { outputFolder: outputDir },
-        })
-        .spawn(cmd, ["--file test_descriptors.json"], {})
-        .code(0)
-        .end()
-      await expect(
-        fsExists(path.join(outputDir, "polkadot-types.d.ts")),
-      ).resolves.toEqual(true)
-      await expect(
-        fsExists(path.join(outputDir, "polkadot.ts")),
-      ).resolves.toEqual(true)
-      await expect(
-        fsExists(path.join(outputDir, "polkadot.d.ts")),
-      ).resolves.toEqual(false)
-    },
-    5 * 60_000,
+describe("cli", async () => {
+  const descriptorJSON = await descriptorSchema.parseAsync(
+    JSON.parse(
+      await fs.readFile("test_descriptors.json", { encoding: "utf-8" }),
+    ),
   )
+
+  Object.entries(descriptorJSON).map(
+    ([key, { outputFolder, descriptors: descriptorRecords }]) =>
+      test(
+        `descriptor codegen - ${key}`,
+        async () => {
+          const expectedDescriptors = mapDescriptorRecords(descriptorRecords)
+
+          await runner()
+            .file("package.json", { bin: { "polkadot-api": cmd } })
+            .spawn(cmd, ["--file test_descriptors.json"], {})
+            .code(0)
+            .end()
+          await expect(
+            fsExists(path.join(outputFolder, `${key}-types.d.ts`)),
+          ).resolves.toEqual(true)
+          await expect(
+            fsExists(path.join(outputFolder, `${key}.ts`)),
+          ).resolves.toEqual(true)
+          await expect(
+            fsExists(path.join(outputFolder, `${key}.d.ts`)),
+          ).resolves.toEqual(false)
+
+          const descriptors: Descriptor[] = (
+            await import(path.join(outputFolder, `${key}.ts`))
+          ).default
+          const actualDescriptors = descriptors.map((d) => ({
+            type: d.type,
+            ...d.props,
+          }))
+
+          expect(actualDescriptors).toStrictEqual(expectedDescriptors)
+        },
+        5 * 60_000,
+      ),
+  )
+
+  function mapDescriptorRecords(
+    records: (typeof descriptorJSON)[string]["descriptors"],
+  ) {
+    type MappedDescriptor = {
+      type: string
+      name: string
+      pallet: string
+      checksum: bigint
+    }
+    const output: MappedDescriptor[] = []
+    for (const [
+      pallet,
+      { constants, storage, events, errors, extrinsics },
+    ] of Object.entries(records)) {
+      for (const [name, checksum] of Object.entries(constants ?? {})) {
+        output.push({
+          type: "const",
+          name,
+          pallet,
+          checksum,
+        })
+      }
+      for (const [name, checksum] of Object.entries(storage ?? {})) {
+        output.push({
+          type: "storage",
+          name,
+          pallet,
+          checksum,
+        })
+      }
+      for (const [name, checksum] of Object.entries(events ?? {})) {
+        output.push({
+          type: "event",
+          name,
+          pallet,
+          checksum,
+        })
+      }
+      for (const [name, checksum] of Object.entries(errors ?? {})) {
+        output.push({
+          type: "error",
+          name,
+          pallet,
+          checksum,
+        })
+      }
+      for (const [name, { checksum }] of Object.entries(extrinsics ?? {})) {
+        output.push({
+          type: "tx",
+          name,
+          pallet,
+          checksum,
+        })
+      }
+    }
+
+    return output
+  }
 })


### PR DESCRIPTION
- fixes missing `len` in extrinsic descriptors
- fixes storage descriptors not compiling due to tsc failing to infer the type of the descriptor. 
- improves integration test --> for each descriptor in descriptor.json we check by using dynamic import to see if it was generated in codegen.