### PR TITLE
chore(cli): add input validation

### DIFF
--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -287,7 +287,7 @@ while (!exit) {
       })
 
       const outputFolder = await input({
-        message: "output folder",
+        message: "codegen output directory",
       })
 
       await writeMetadataToDisk(data, metadataFilePath)
@@ -307,7 +307,10 @@ while (!exit) {
         })
       } else {
         const fileName = await input({
-          message: "output file",
+          message: "descriptor json file name",
+          validate: (value) =>
+            value !== outputFolder ||
+            "descriptor json file name cannot be equal to codegen output directory",
         })
 
         await outputDescriptors({


### PR DESCRIPTION
Adds inputs validation for the descriptor json file name such that it cannot be equal to the codegen output directory.