### PR TITLE
Better `json-rpc-provider`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
           pnpm pack --dir packages/cli
           pnpm pack --dir packages/client
           pnpm pack --dir packages/json-rpc-provider
+          pnpm pack --dir packages/json-rpc-provider-proxy
           pnpm pack --dir packages/sc-provider
           pnpm pack --dir packages/substrate-bindings
           pnpm pack --dir packages/substrate-client
@@ -81,6 +82,10 @@ jobs:
         with:
           name: package
           path: ./packages/json-rpc-provider/*.tgz
+      - uses: actions/upload-artifact@v3
+        with:
+          name: package
+          path: ./packages/json-rpc-provider-proxy/*.tgz
       - uses: actions/upload-artifact@v3
         with:
           name: package

--- a/experiments/src/all-nominators.ts
+++ b/experiments/src/all-nominators.ts
@@ -1,4 +1,4 @@
-import { GetProvider, WellKnownChain } from "@polkadot-api/sc-provider"
+import { ConnectProvider, WellKnownChain } from "@polkadot-api/sc-provider"
 import { createClient } from "@polkadot-api/substrate-client"
 import { createProvider } from "./smolldot-worker"
 import { getObservableClient } from "@polkadot-api/client"
@@ -6,18 +6,12 @@ import { firstValueFrom } from "rxjs"
 
 const provider = createProvider(WellKnownChain.polkadot)
 
-const withLogsProvider = (input: GetProvider): GetProvider => {
-  return (onMsg, onStatus) => {
-    const result = input(
-      (msg) => {
-        console.log("<< " + msg)
-        onMsg(msg)
-      },
-      (status) => {
-        console.log("STATUS CHANGED =>" + status)
-        onStatus(status)
-      },
-    )
+const withLogsProvider = (input: ConnectProvider): ConnectProvider => {
+  return (onMsg) => {
+    const result = input((msg) => {
+      console.log("<< " + msg)
+      onMsg(msg)
+    })
 
     return {
       ...result,

--- a/experiments/src/getMetadata.ts
+++ b/experiments/src/getMetadata.ts
@@ -1,7 +1,7 @@
 import {
   ScProvider,
   WellKnownChain,
-  GetProvider,
+  ConnectProvider,
 } from "@polkadot-api/sc-provider"
 import { createClient } from "@polkadot-api/substrate-client"
 import {
@@ -19,18 +19,12 @@ const smProvider = ScProvider(
 }*/,
 )
 
-const withLogsProvider = (input: GetProvider): GetProvider => {
-  return (onMsg, onStatus) => {
-    const result = input(
-      (msg) => {
-        console.log("<< " + msg)
-        onMsg(msg)
-      },
-      (status) => {
-        console.log("STATUS CHANGED =>" + status)
-        onStatus(status)
-      },
-    )
+const withLogsProvider = (input: ConnectProvider): ConnectProvider => {
+  return (onMsg) => {
+    const result = input((msg) => {
+      console.log("<< " + msg)
+      onMsg(msg)
+    })
 
     return {
       ...result,

--- a/packages/cli/src/smolldot-worker.ts
+++ b/packages/cli/src/smolldot-worker.ts
@@ -10,8 +10,7 @@ if (!parentPort) {
 }
 
 const provider = getProvider(
-  (msg) => parentPort.postMessage({ type: "message", value: msg }),
-  (status) => parentPort.postMessage({ type: "status", value: status }),
+  (msg) => parentPort.postMessage(msg)
 )
 
 parentPort.on("message", (msg) => {
@@ -19,12 +18,8 @@ parentPort.on("message", (msg) => {
     case "send":
       provider.send(msg.value)
       break
-    case "open":
-      provider.open()
-      break
-    case "close":
-      provider.close()
-      break
+    case "disconnect":
+      provider.disconnect()
   }
 })
 `

--- a/packages/json-rpc-provider-proxy/README.md
+++ b/packages/json-rpc-provider-proxy/README.md
@@ -1,0 +1,1 @@
+# @polkadot-api/json-rpc-provider-proxy

--- a/packages/json-rpc-provider-proxy/package.json
+++ b/packages/json-rpc-provider-proxy/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@polkadot-api/json-rpc-provider-proxy",
+  "version": "0.0.0",
+  "author": "Josep M Sobrepere (https://github.com/josepot)",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/paritytech/polkadot-api.git"
+  },
+  "license": "MIT",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "node": {
+        "production": {
+          "import": "./dist/index.mjs",
+          "require": "./dist/min/index.js",
+          "default": "./dist/index.js"
+        },
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "module": "./dist/index.mjs",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "browser": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --noEmit && tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2020 --format esm,cjs --dts && tsup-node src/index.ts --clean --sourcemap --platform neutral --target=es2020 --format cjs --dts --minify --out-dir dist/min",
+    "test": "echo 'no tests'",
+    "lint": "prettier --check README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
+    "format": "prettier --write README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
+    "prepack": "pnpm run build"
+  },
+  "prettier": {
+    "printWidth": 80,
+    "semi": false,
+    "trailingComma": "all"
+  },
+  "devDependencies": {
+    "@polkadot-api/json-rpc-provider": "workspace:*"
+  }
+}

--- a/packages/json-rpc-provider-proxy/src/get-sync-provider.ts
+++ b/packages/json-rpc-provider-proxy/src/get-sync-provider.ts
@@ -1,0 +1,132 @@
+import type { RequestId } from "./internal-types"
+import type { ConnectProvider, Provider } from "@polkadot-api/json-rpc-provider"
+import { getSubscriptionManager } from "./subscription-manager"
+
+export type ConnectAsyncProvider = (
+  onMessage: (message: string) => void,
+  onHalt: () => void,
+) => Provider
+
+export const getSyncProvider =
+  (input: () => Promise<ConnectAsyncProvider>): ConnectProvider =>
+  (onMessage) => {
+    // if it's null it means that the consumer has called `disconnect`
+    // of it's a Promise it means that it's being respolved, otherwise it's resolved
+    let provider: Provider | Promise<Provider> | null
+
+    let bufferedMessages: Array<string> = []
+    const pendingResponses = new Set<RequestId>()
+    const subscriptionManager = getSubscriptionManager()
+
+    const onMessageProxy = (message: string) => {
+      let parsed: any
+      try {
+        parsed = JSON.parse(message)
+      } catch (_) {
+        console.error(`Unable to parse incoming message: ${message}`)
+        return
+      }
+
+      if (parsed.id !== undefined) {
+        pendingResponses.delete(parsed.id)
+        subscriptionManager.onResponse(parsed)
+      } else {
+        subscriptionManager.onNotifiaction(parsed)
+      }
+
+      onMessage(message)
+    }
+
+    const send = (message: string) => {
+      if (!provider) return
+
+      const parsed = JSON.parse(message)
+      subscriptionManager.onSent(parsed)
+      if (parsed.id) pendingResponses.add(parsed.id)
+
+      if (provider instanceof Promise) {
+        bufferedMessages.push(message)
+      } else provider.send(message)
+    }
+
+    const onHalt = (): Promise<Provider> => {
+      bufferedMessages = []
+      const pendingResponsesCopy = [...pendingResponses]
+      pendingResponses.clear()
+
+      // It needs to restart before sending the errored
+      // responses/notifications because the consumer may
+      // react to those by sending new requests
+      const result = start()
+
+      subscriptionManager.onAbort().forEach((msg) => {
+        onMessage(JSON.stringify(msg))
+      })
+
+      pendingResponsesCopy.forEach((id) => {
+        onMessage(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            error: { code: -32603, message: "Internal error" },
+            id,
+          }),
+        )
+      })
+
+      return result
+    }
+
+    const start = (): Promise<Provider> => {
+      const onResolve = (getProvider: ConnectAsyncProvider) => {
+        let halted = false
+        const _onHalt = () => {
+          if (halted) return
+          halted = true
+          onHalt()
+        }
+        const _onMessageProxy = (msg: string) => {
+          if (halted) return
+          onMessageProxy(msg)
+        }
+
+        const result = getProvider(_onMessageProxy, _onHalt)
+        bufferedMessages.forEach((m) => {
+          result.send(m)
+        })
+        bufferedMessages = []
+        return (provider = result)
+      }
+
+      provider = input().then(onResolve, withMacroTask(onHalt))
+      return provider
+    }
+
+    const disconnect = () => {
+      if (!provider) return
+
+      const finishIt = (input: Provider) => {
+        subscriptionManager.onAbort()
+        pendingResponses.clear()
+        provider = null
+        input.disconnect()
+      }
+
+      if (provider instanceof Promise) {
+        provider.then(finishIt)
+        provider = null
+      } else finishIt(provider)
+    }
+
+    start()
+    return {
+      send,
+      disconnect,
+    }
+  }
+
+const withMacroTask =
+  <Args extends Array<any>, T>(
+    inputFn: (...args: Args) => Promise<T>,
+  ): ((...args: Args) => Promise<T>) =>
+  (...args) =>
+    new Promise((res) => setTimeout(res, 0)).then(() => inputFn(...args))

--- a/packages/json-rpc-provider-proxy/src/get-sync-provider.ts
+++ b/packages/json-rpc-provider-proxy/src/get-sync-provider.ts
@@ -16,7 +16,7 @@ export const getSyncProvider =
 
     let bufferedMessages: Array<string> = []
     const pendingResponses = new Set<RequestId>()
-    const subscriptionManager = getSubscriptionManager()
+    const subscriptionManager = getSubscriptionManager(onMessage)
 
     const onMessageProxy = (message: string) => {
       let parsed: any
@@ -65,10 +65,7 @@ export const getSyncProvider =
       // react to those by sending new requests
       const result = start()
 
-      subscriptionManager.onAbort().forEach((msg) => {
-        onMessage(JSON.stringify(msg))
-      })
-
+      subscriptionManager.onAbort()
       pendingResponsesCopy.forEach((id) => {
         onMessage(
           JSON.stringify({
@@ -111,7 +108,7 @@ export const getSyncProvider =
       if (!provider) return
 
       const finishIt = (input: Provider | null) => {
-        subscriptionManager.onAbort()
+        subscriptionManager.onDisconnect()
         pendingResponses.clear()
         provider = null
         input?.disconnect()

--- a/packages/json-rpc-provider-proxy/src/index.ts
+++ b/packages/json-rpc-provider-proxy/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./get-sync-provider"

--- a/packages/json-rpc-provider-proxy/src/internal-types.ts
+++ b/packages/json-rpc-provider-proxy/src/internal-types.ts
@@ -1,0 +1,20 @@
+export type RequestId = string | number | null
+export type SubscriptionId = string | number
+export type JsonMessage = {
+  jsonrpc: "2.0"
+  method: string
+  params: {}
+}
+
+export interface SubscriptionLogic {
+  onSent: (parsed: any) =>
+    | {
+        type: "subscribe"
+        id: RequestId
+        onRes: (parsed: any) => { id: SubscriptionId } | null
+      }
+    | { type: "unsubscribe"; id: SubscriptionId }
+    | null
+  onNotification: (parsed: any) => { type: "end"; id: SubscriptionId } | null
+  onAbort: (id: SubscriptionId) => JsonMessage
+}

--- a/packages/json-rpc-provider-proxy/src/internal-types.ts
+++ b/packages/json-rpc-provider-proxy/src/internal-types.ts
@@ -16,5 +16,5 @@ export interface SubscriptionLogic {
     | { type: "unsubscribe"; id: SubscriptionId }
     | null
   onNotification: (parsed: any) => { type: "end"; id: SubscriptionId } | null
-  onAbort: (id: SubscriptionId) => JsonMessage
+  onAbort: (id: SubscriptionId) => void
 }

--- a/packages/json-rpc-provider-proxy/src/subscription-manager/chainHeadFollow.ts
+++ b/packages/json-rpc-provider-proxy/src/subscription-manager/chainHeadFollow.ts
@@ -1,0 +1,52 @@
+import { SubscriptionId, SubscriptionLogic } from "@/internal-types"
+
+const START_METHOD = "chainHead_unstable_follow"
+const STOP_METHOD = "chainHead_unstable_unfollow"
+const NOTIFICATION_METHOD = "chainHead_unstable_followEvent"
+const ABORT_EVENT = "stop"
+
+const terminalEvents = new Set([
+  ABORT_EVENT,
+  "operationInaccessible",
+  "operationError",
+])
+
+export const chainHeadFollow: SubscriptionLogic = {
+  onSent(parsed) {
+    if (parsed.method === START_METHOD)
+      return {
+        type: "subscribe",
+        id: parsed.id,
+        onRes: (innerParsed) =>
+          innerParsed.id === parsed.id ? { id: innerParsed.result } : null,
+      }
+
+    if (parsed.method === STOP_METHOD)
+      return {
+        type: "unsubscribe",
+        id: Object.values(parsed.params)[0] as string,
+      }
+
+    return null
+  },
+  onNotification(parsed) {
+    if (parsed.method !== NOTIFICATION_METHOD) return null
+
+    return terminalEvents.has(parsed.params.result.event)
+      ? {
+          type: "end",
+          id: parsed.params.subscription as SubscriptionId,
+        }
+      : null
+  },
+  onAbort: (id) => ({
+    jsonrpc: "2.0",
+    method: NOTIFICATION_METHOD,
+    params: {
+      subscription: id,
+      result: {
+        event: ABORT_EVENT,
+      },
+    },
+  }),
+}

--- a/packages/json-rpc-provider-proxy/src/subscription-manager/chainHeadFollow.ts
+++ b/packages/json-rpc-provider-proxy/src/subscription-manager/chainHeadFollow.ts
@@ -11,7 +11,9 @@ const terminalEvents = new Set([
   "operationError",
 ])
 
-export const chainHeadFollow: SubscriptionLogic = {
+export const chainHeadFollow = (
+  onMessage: (msg: string) => void,
+): SubscriptionLogic => ({
   onSent(parsed) {
     if (parsed.method === START_METHOD)
       return {
@@ -39,14 +41,18 @@ export const chainHeadFollow: SubscriptionLogic = {
         }
       : null
   },
-  onAbort: (id) => ({
-    jsonrpc: "2.0",
-    method: NOTIFICATION_METHOD,
-    params: {
-      subscription: id,
-      result: {
-        event: ABORT_EVENT,
-      },
-    },
-  }),
-}
+  onAbort: (id) => {
+    onMessage(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: NOTIFICATION_METHOD,
+        params: {
+          subscription: id,
+          result: {
+            event: ABORT_EVENT,
+          },
+        },
+      }),
+    )
+  },
+})

--- a/packages/json-rpc-provider-proxy/src/subscription-manager/index.ts
+++ b/packages/json-rpc-provider-proxy/src/subscription-manager/index.ts
@@ -1,0 +1,1 @@
+export * from "./subscription-manager"

--- a/packages/json-rpc-provider-proxy/src/subscription-manager/subscription-manager.ts
+++ b/packages/json-rpc-provider-proxy/src/subscription-manager/subscription-manager.ts
@@ -1,0 +1,76 @@
+import type {
+  RequestId,
+  SubscriptionId,
+  SubscriptionLogic,
+  JsonMessage,
+} from "../internal-types"
+import { chainHeadFollow } from "./chainHeadFollow"
+import { txSubmitAndWatch } from "./transaction-submit-watch"
+
+export const addSubscription = ({
+  onSent,
+  onNotification,
+  onAbort,
+}: SubscriptionLogic) => {
+  const preActive = new Map<
+    RequestId,
+    (parsed: any) => { id: SubscriptionId } | null
+  >()
+  const active = new Set<SubscriptionId>()
+
+  return {
+    onSent(parsed: any) {
+      const result = onSent(parsed)
+      if (!result) return
+      if (result.type === "subscribe") {
+        preActive.set(result.id, result.onRes)
+      } else {
+        active.delete(result.id)
+      }
+    },
+    onResponse(parsed: any) {
+      const match = preActive.get(parsed.id)?.(parsed)
+      if (!match) return
+      preActive.delete(parsed.id)
+      active.add(match.id)
+    },
+    onNotifiaction(parsed: any) {
+      const result = onNotification(parsed)
+      if (!result) return
+      active.delete(result.id)
+    },
+    onAbort(): Array<JsonMessage> {
+      preActive.clear()
+      const result = [...active].map(onAbort)
+      active.clear()
+      return result
+    },
+  }
+}
+
+export const getSubscriptionManager = () => {
+  const subscriptions = [chainHeadFollow, txSubmitAndWatch].map((logic) =>
+    addSubscription(logic),
+  )
+
+  return {
+    onSent(parsed: any) {
+      subscriptions.forEach((s) => {
+        s.onSent(parsed)
+      })
+    },
+    onResponse(parsed: any) {
+      subscriptions.forEach((s) => {
+        s.onResponse(parsed)
+      })
+    },
+    onNotifiaction(parsed: any) {
+      subscriptions.forEach((s) => {
+        s.onNotifiaction(parsed)
+      })
+    },
+    onAbort(): Array<JsonMessage> {
+      return subscriptions.map((s) => s.onAbort()).flat()
+    },
+  }
+}

--- a/packages/json-rpc-provider-proxy/src/subscription-manager/transaction-submit-watch.ts
+++ b/packages/json-rpc-provider-proxy/src/subscription-manager/transaction-submit-watch.ts
@@ -7,7 +7,9 @@ const ABORT_EVENT = "dropped"
 
 const terminalEvents = new Set([ABORT_EVENT, "finalized", "error", "invalid"])
 
-export const txSubmitAndWatch: SubscriptionLogic = {
+export const txSubmitAndWatch = (
+  onMessage: (msg: string) => void,
+): SubscriptionLogic => ({
   onSent(parsed) {
     if (parsed.method === START_METHOD)
       return {
@@ -35,14 +37,18 @@ export const txSubmitAndWatch: SubscriptionLogic = {
         }
       : null
   },
-  onAbort: (id) => ({
-    jsonrpc: "2.0",
-    method: NOTIFICATION_METHOD,
-    params: {
-      subscription: id,
-      result: {
-        event: ABORT_EVENT,
-      },
-    },
-  }),
-}
+  onAbort: (id) => {
+    onMessage(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: NOTIFICATION_METHOD,
+        params: {
+          subscription: id,
+          result: {
+            event: ABORT_EVENT,
+          },
+        },
+      }),
+    )
+  },
+})

--- a/packages/json-rpc-provider-proxy/src/subscription-manager/transaction-submit-watch.ts
+++ b/packages/json-rpc-provider-proxy/src/subscription-manager/transaction-submit-watch.ts
@@ -1,0 +1,48 @@
+import { SubscriptionId, SubscriptionLogic } from "@/internal-types"
+
+const START_METHOD = "transaction_unstable_submitAndWatch"
+const STOP_METHOD = "transaction_unstable_unwatch"
+const NOTIFICATION_METHOD = "transaction_unstable_watchEvent"
+const ABORT_EVENT = "dropped"
+
+const terminalEvents = new Set([ABORT_EVENT, "finalized", "error", "invalid"])
+
+export const txSubmitAndWatch: SubscriptionLogic = {
+  onSent(parsed) {
+    if (parsed.method === START_METHOD)
+      return {
+        type: "subscribe",
+        id: parsed.id,
+        onRes: (innerParsed) =>
+          innerParsed.id === parsed.id ? { id: innerParsed.result } : null,
+      }
+
+    if (parsed.method === STOP_METHOD)
+      return {
+        type: "unsubscribe",
+        id: Object.values(parsed.params)[0] as string,
+      }
+
+    return null
+  },
+  onNotification(parsed) {
+    if (parsed.method !== NOTIFICATION_METHOD) return null
+
+    return terminalEvents.has(parsed.params.result.event)
+      ? {
+          type: "end",
+          id: parsed.params.subscription as SubscriptionId,
+        }
+      : null
+  },
+  onAbort: (id) => ({
+    jsonrpc: "2.0",
+    method: NOTIFICATION_METHOD,
+    params: {
+      subscription: id,
+      result: {
+        event: ABORT_EVENT,
+      },
+    },
+  }),
+}

--- a/packages/json-rpc-provider-proxy/tsconfig.json
+++ b/packages/json-rpc-provider-proxy/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base",
+  "include": ["src", "tests"],
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["*"]
+    }
+  }
+}

--- a/packages/json-rpc-provider/src/index.ts
+++ b/packages/json-rpc-provider/src/index.ts
@@ -1,12 +1,8 @@
 export interface Provider {
   send: (message: string) => void
-  open: () => void
-  close: () => void
+  disconnect: () => void
 }
 
-export type ProviderStatus = "connected" | "disconnected"
-
-export declare type GetProvider = (
+export declare type ConnectProvider = (
   onMessage: (message: string) => void,
-  onStatus: (status: ProviderStatus) => void,
 ) => Provider

--- a/packages/sc-provider/package.json
+++ b/packages/sc-provider/package.json
@@ -47,6 +47,7 @@
     "trailingComma": "all"
   },
   "dependencies": {
+    "@polkadot-api/json-rpc-provider-proxy": "workspace:*",
     "@substrate/connect": "^0.7.32"
   },
   "devDependencies": {

--- a/packages/substrate-client/src/index.ts
+++ b/packages/substrate-client/src/index.ts
@@ -1,7 +1,6 @@
 import {
-  type GetProvider,
+  type ConnectProvider,
   type Provider,
-  type ProviderStatus,
 } from "@polkadot-api/json-rpc-provider"
 import { getTransaction } from "./transaction/transaction"
 import { getChainHead } from "./chainhead"
@@ -14,7 +13,7 @@ import type { ChainHead } from "./chainhead"
 import type { Transaction } from "./transaction"
 import { UnsubscribeFn } from "./common-types"
 
-export type { GetProvider, Provider, ProviderStatus }
+export type { ConnectProvider, Provider }
 
 export type * from "./common-types"
 export type * from "./client"
@@ -42,9 +41,8 @@ export interface SubstrateClient {
   ) => UnsubscribeFn
 }
 
-export const createClient = (provider: GetProvider): SubstrateClient => {
+export const createClient = (provider: ConnectProvider): SubstrateClient => {
   const client = createRawClient(provider)
-  client.connect()
 
   return {
     chainHead: getChainHead(client.request as ClientRequest<any, any>),

--- a/packages/substrate-client/tests/fixtures.ts
+++ b/packages/substrate-client/tests/fixtures.ts
@@ -1,6 +1,8 @@
-import type { GetProvider } from "@polkadot-api/json-rpc-provider"
+import type { ConnectProvider } from "@polkadot-api/json-rpc-provider"
 import { FollowResponse, IRpcError, createClient } from "@/."
-import { vi } from "vitest"
+import * as vitest from "vitest"
+
+const vi = vitest.vi
 
 export const parseError: IRpcError = {
   code: -32700,
@@ -15,16 +17,13 @@ export const createTestClient = () => {
 
   const receivedMessages: Array<string> = []
 
-  const provider: GetProvider = (_onMessage, _onStatus) => {
+  const provider: ConnectProvider = (_onMessage) => {
     onMessage = _onMessage
     return {
       send(msg) {
         receivedMessages.push(msg)
       },
-      open() {
-        _onStatus("connected")
-      },
-      close() {},
+      disconnect() {},
     }
   }
 

--- a/packages/tx-helper/src/types.ts
+++ b/packages/tx-helper/src/types.ts
@@ -1,10 +1,10 @@
-import type { GetProvider } from "@polkadot-api/json-rpc-provider"
+import type { ConnectProvider } from "@polkadot-api/json-rpc-provider"
 
 export type Callback<T> = (value: T) => void
 
 export type GetTxCreator = (
   // The `TransactionCreator` communicates with the Chain to obtain metadata, latest block, nonce, etc.
-  chainProvider: GetProvider,
+  chainProvider: ConnectProvider,
 
   // This callback is invoked in order to capture the necessary user input
   // for creating the transaction.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,8 +194,17 @@ importers:
 
   packages/json-rpc-provider: {}
 
+  packages/json-rpc-provider-proxy:
+    devDependencies:
+      '@polkadot-api/json-rpc-provider':
+        specifier: workspace:*
+        version: link:../json-rpc-provider
+
   packages/sc-provider:
     dependencies:
+      '@polkadot-api/json-rpc-provider-proxy':
+        specifier: workspace:*
+        version: link:../json-rpc-provider-proxy
       '@substrate/connect':
         specifier: ^0.7.32
         version: 0.7.32


### PR DESCRIPTION
This PR is a follow-up to [this discussion](https://forum.polkadot.network/t/polkadot-provider-api-a-common-interface-for-building-decentralized-applications/4128/9?u=josep) I had with @tomaka.

**Main Changes**:
- Leveraging the capabilities of the new JSON-RPC API, the transportation layer's status is now hidden within the `json-rpc-provider`. This has allowed us to simplify the interfaces within `@polkadot-api/json-rpc-provider` as shown below:
```ts
export interface Provider {
  send: (message: string) => void;
  disconnect: () => void;
}
export declare type ConnectProvider = (
  onMessage: (message: string) => void,
) => Provider;
```
- Introduced a new package, `@polkadot-api/json-rpc-provider-proxy`, to manage the transportation layer's status across different implementations. The main feature here is the `getSyncProvider` function, which effectively transforms an asynchronous provider to a synchronous one.
```ts
import { Provider, ConnectProvider } from "@polkadot-api/json-rpc-provider"

type ConnectAsyncProvider = (
  onMessage: (message: string) => void,
  onHalt: () => void,
) => Provider

declare const getSyncProvider: (
  input: () => Promise<ConnectAsyncProvider>,
) => ConnectProvider

export { ConnectAsyncProvider, getSyncProvider }
```
- An illustrative example on how a synchronous `WebSocketProvider` can be achieved using the `getSyncProvider`.
```ts
export const WebSocketProvider = (uri: string, protocols?: string | string[]) =>
  getSyncProvider(async () => {
    const socket = new WebSocket(uri, protocols)

    await new Promise<void>((resolve, reject) => {
      const onOpen = () => {
        resolve()
        socket.removeEventListener("error", onError)
      }
      socket.addEventListener("open", onOpen, { once: true })

      const onError = (e: Event) => {
        reject(e)
        socket.removeEventListener("open", onOpen)
      }
      socket.addEventListener("error", onError, { once: true })
    })

    return (onMessage, onHalt) => {
      const _onMessage = (e: MessageEvent<string>) => {
        onMessage(e.data)
      }

      socket.addEventListener("message", _onMessage)
      socket.addEventListener("error", onHalt)
      socket.addEventListener("close", onHalt)

      return {
        send(msg) {
          socket.send(msg)
        },
        disconnect() {
          socket.removeEventListener("message", _onMessage)
          socket.removeEventListener("error", onHalt)
          socket.removeEventListener("close", onHalt)
          socket.close()
        },
      }
    }
  })
```

**Commit Breakdown**:
1. The first commit updates the interface of the `json-rpc-provider` and introduces `json-rpc-provider-proxy`.
2. The second commit refactors the entire codebase to align with the updated interface.

**Benefits**:
This refactoring leads to a more streamlined codebase 🎉.