### PR TITLE
tx-helper improvements

### DIFF
--- a/packages/tx-helper/src/get-tx-creator/get-tx-creator.ts
+++ b/packages/tx-helper/src/get-tx-creator/get-tx-creator.ts
@@ -32,14 +32,15 @@ export const getTxCreator: GetTxCreator = (chainProvider, onCreateTx) => {
     }),
   )
 
-  const createTx: CreateTx = async (from, callData, cb) => {
-    const { signer, extra, additional } = await firstValueFrom(
-      metaCtx$.pipe(
-        mergeMap(getTxData(from, callData, chainHead, cb ?? onCreateTx)),
-      ),
+  const createTx: CreateTx = async (from, callData, cb = onCreateTx) => {
+    const {
+      signer,
+      signedExtensions: { value: extra, additionalSigned },
+    } = await firstValueFrom(
+      metaCtx$.pipe(mergeMap(getTxData(from, callData, chainHead, cb))),
     )
 
-    const toSign = mergeUint8(callData, extra, additional)
+    const toSign = mergeUint8(callData, extra, additionalSigned)
     const signed = await signer.signer(
       toSign.length > 256 ? blake2b(toSign) : toSign,
     )

--- a/packages/tx-helper/src/get-tx-creator/get-tx-creator.ts
+++ b/packages/tx-helper/src/get-tx-creator/get-tx-creator.ts
@@ -32,9 +32,11 @@ export const getTxCreator: GetTxCreator = (chainProvider, onCreateTx) => {
     }),
   )
 
-  const createTx: CreateTx = async (from, callData) => {
+  const createTx: CreateTx = async (from, callData, cb) => {
     const { signer, extra, additional } = await firstValueFrom(
-      metaCtx$.pipe(mergeMap(getTxData(from, callData, chainHead, onCreateTx))),
+      metaCtx$.pipe(
+        mergeMap(getTxData(from, callData, chainHead, cb ?? onCreateTx)),
+      ),
     )
 
     const toSign = mergeUint8(callData, extra, additional)

--- a/packages/tx-helper/src/internal-types.ts
+++ b/packages/tx-helper/src/internal-types.ts
@@ -11,10 +11,15 @@ export interface ChainExtensionCtx {
   chainHead: ReturnType<ReturnType<typeof getObservableClient>["chainHead$"]>
 }
 
-export interface SignedExtension {
-  extra: Observable<Uint8Array>
-  additional: Observable<Uint8Array>
-}
+export type SignedExtension = Record<
+  "value" | "additionalSigned",
+  Observable<Uint8Array>
+>
+
+export type FlattenSignedExtension = Observable<{
+  value: Uint8Array
+  additionalSigned: Uint8Array
+}>
 
 export type GetChainSignedExtension = (
   ctx: ChainExtensionCtx,
@@ -23,7 +28,4 @@ export type GetChainSignedExtension = (
 export type GetUserSignedExtension<K extends UserSignedExtensionName> = (
   input$: Observable<UserSignedExtensionsInput<K>>,
   ctx: ChainExtensionCtx,
-) => {
-  extra: Observable<Uint8Array>
-  additional: Observable<Uint8Array>
-}
+) => SignedExtension

--- a/packages/tx-helper/src/signed-extensions/chain/CheckGenesis.ts
+++ b/packages/tx-helper/src/signed-extensions/chain/CheckGenesis.ts
@@ -2,6 +2,6 @@ import type { GetChainSignedExtension } from "@/internal-types"
 import { empty$, genesisHashFromCtx } from "../utils"
 
 export const CheckGenesis: GetChainSignedExtension = (ctx) => ({
-  additional: genesisHashFromCtx(ctx),
-  extra: empty$,
+  value: empty$,
+  additionalSigned: genesisHashFromCtx(ctx),
 })

--- a/packages/tx-helper/src/signed-extensions/chain/CheckNonce.ts
+++ b/packages/tx-helper/src/signed-extensions/chain/CheckNonce.ts
@@ -11,7 +11,7 @@ const lenToDecoder = {
 }
 
 export const CheckNonce: GetChainSignedExtension = (ctx) => ({
-  extra: ctx.chainHead
+  value: ctx.chainHead
     .call$(ctx.at, "AccountNonceApi_account_nonce", toHex(ctx.from))
     .pipe(
       map((result) => {
@@ -22,5 +22,5 @@ export const CheckNonce: GetChainSignedExtension = (ctx) => ({
         return compact.enc(decoder(bytes))
       }),
     ),
-  additional: empty$,
+  additionalSigned: empty$,
 })

--- a/packages/tx-helper/src/signed-extensions/chain/CheckSpecVersion.ts
+++ b/packages/tx-helper/src/signed-extensions/chain/CheckSpecVersion.ts
@@ -2,6 +2,6 @@ import type { GetChainSignedExtension } from "@/internal-types"
 import { empty$, systemVersionProp$ } from "../utils"
 
 export const CheckSpecVersion: GetChainSignedExtension = ({ metadata }) => ({
-  additional: systemVersionProp$("spec_version", metadata),
-  extra: empty$,
+  additionalSigned: systemVersionProp$("spec_version", metadata),
+  value: empty$,
 })

--- a/packages/tx-helper/src/signed-extensions/chain/CheckTxVersion.ts
+++ b/packages/tx-helper/src/signed-extensions/chain/CheckTxVersion.ts
@@ -2,6 +2,6 @@ import type { GetChainSignedExtension } from "@/internal-types"
 import { empty$, systemVersionProp$ } from "../utils"
 
 export const CheckTxVersion: GetChainSignedExtension = ({ metadata }) => ({
-  additional: systemVersionProp$("transaction_version", metadata),
-  extra: empty$,
+  additionalSigned: systemVersionProp$("transaction_version", metadata),
+  value: empty$,
 })

--- a/packages/tx-helper/src/signed-extensions/user/ChargeAssetTxPayment.ts
+++ b/packages/tx-helper/src/signed-extensions/user/ChargeAssetTxPayment.ts
@@ -11,6 +11,6 @@ const encoder = Struct({
 export const ChargeAssetTxPayment: GetUserSignedExtension<
   "ChargeAssetTxPayment"
 > = (user$) => ({
-  extra: user$.pipe(map(encoder)),
-  additional: empty$,
+  value: user$.pipe(map(encoder)),
+  additionalSigned: empty$,
 })

--- a/packages/tx-helper/src/signed-extensions/user/ChargeTransactionPayment.ts
+++ b/packages/tx-helper/src/signed-extensions/user/ChargeTransactionPayment.ts
@@ -6,6 +6,6 @@ import { empty$ } from "../utils"
 export const ChargeTransactionPayment: GetUserSignedExtension<
   "ChargeTransactionPayment"
 > = (user$) => ({
-  extra: user$.pipe(map(compactBn.enc)),
-  additional: empty$,
+  value: user$.pipe(map(compactBn.enc)),
+  additionalSigned: empty$,
 })

--- a/packages/tx-helper/src/signed-extensions/user/CheckMortality.ts
+++ b/packages/tx-helper/src/signed-extensions/user/CheckMortality.ts
@@ -42,12 +42,12 @@ export const CheckMortality: GetUserSignedExtension<"CheckMortality"> = (
     .pipe(map((x) => SystemNumber.dec(x!)))
 
   return {
-    additional: userInput$.pipe(
+    additionalSigned: userInput$.pipe(
       mergeMap((input) =>
         input.mortal ? of(fromHex(ctx.at)) : genesisHashFromCtx(ctx),
       ),
     ),
-    extra: combineLatest([userInput$, blockNumber$]).pipe(
+    value: combineLatest([userInput$, blockNumber$]).pipe(
       map(([input, blockNumber]) =>
         input.mortal
           ? mortal({

--- a/packages/tx-helper/src/types.ts
+++ b/packages/tx-helper/src/types.ts
@@ -63,6 +63,15 @@ export type ConsumerCallback<T extends Array<UserSignedExtensionName>> = {
 export type CreateTx = (
   from: Uint8Array, // The public-key of the sender
   callData: Uint8Array,
+  consumerCallback?: <
+    UserSignedExtensionsName extends Array<UserSignedExtensionName>,
+  >(
+    context: OnCreateTxCtx<UserSignedExtensionsName>,
+
+    // The function to call once the user has decided to cancel or proceed with the tx.
+    // Passing `null` indicates that the user has decided not to sing the tx.
+    callback: Callback<null | ConsumerCallback<UserSignedExtensionsName>>,
+  ) => void,
 ) => Promise<Uint8Array>
 
 export type SigningType = "Ed25519" | "Sr25519" | "Ecdsa"

--- a/packages/tx-helper/src/types.ts
+++ b/packages/tx-helper/src/types.ts
@@ -63,13 +63,8 @@ export type ConsumerCallback<T extends Array<UserSignedExtensionName>> = {
 export type CreateTx = (
   from: Uint8Array, // The public-key of the sender
   callData: Uint8Array,
-  consumerCallback?: <
-    UserSignedExtensionsName extends Array<UserSignedExtensionName>,
-  >(
+  cb?: <UserSignedExtensionsName extends Array<UserSignedExtensionName>>(
     context: OnCreateTxCtx<UserSignedExtensionsName>,
-
-    // The function to call once the user has decided to cancel or proceed with the tx.
-    // Passing `null` indicates that the user has decided not to sing the tx.
     callback: Callback<null | ConsumerCallback<UserSignedExtensionsName>>,
   ) => void,
 ) => Promise<Uint8Array>


### PR DESCRIPTION
- The resulting `createTx` function now takes an optional argument which allows the consumer to provide a specific callback function, which will be used for that particular call.
- Cleaning up the code a bit and making variable names more consistent with the field-names that appear on the metadata.