### PR TITLE
fix: txdescriptor event and error generics

### DIFF
--- a/packages/substrate-bindings/src/descriptors.ts
+++ b/packages/substrate-bindings/src/descriptors.ts
@@ -54,8 +54,8 @@ export interface ErrorDescriptor<
 export interface TxDescriptor<
   Common extends DescriptorCommon<string, string>,
   Codecs extends ArgsWithoutPayloadCodec<any>,
-  Events extends Tuple<EventDescriptor<any, any>>,
-  Errors extends Tuple<ErrorDescriptor<any, any>>,
+  Events extends Array<EventDescriptor<any, any>>,
+  Errors extends Array<ErrorDescriptor<any, any>>,
 > {
   type: "tx"
   props: Common
@@ -143,8 +143,8 @@ export const getPalletCreator = <Pallet extends string>(pallet: Pallet) => {
   const getTxDescriptor = <
     Name extends string,
     Codecs extends ArgsWithoutPayloadCodec<any>,
-    Events extends Tuple<EventDescriptor<any, any>>,
-    Errors extends Tuple<ErrorDescriptor<any, any>>,
+    Events extends Array<EventDescriptor<any, any>>,
+    Errors extends Array<ErrorDescriptor<any, any>>,
   >(
     checksum: bigint,
     name: Name,


### PR DESCRIPTION
Changes the generic to use array instead of tuple because if we use tuple we always need to have 1 element. If we must have 1 element, it prevents a "fire and forget" usage of the tx where the user doesn't care about the events or errors.