### PR TITLE
fix: publish by uploading exactly 1 artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,8 +159,8 @@ jobs:
       - name: Run Playwright tests
         run: pnpm exec playwright test --project=chromium
         working-directory: ./examples/extension
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: playwright-report
-          path: examples/extension/playwright-report/
+      # - uses: actions/upload-artifact@v3
+      #   if: always()
+      #   with:
+      #     name: playwright-report
+      #     path: examples/extension/playwright-report/


### PR DESCRIPTION
Fixes https://github.com/paritytech/npm_publish_automation/actions/runs/6812714969/job/18525679043#step:6:24

`npm_publish_automation` expects a single artifact
https://github.com/paritytech/npm_publish_automation/blob/3fc4f3af68fe9974abd4250a9575f37291de9009/publishPackages.ts#L26-L28