### PR TITLE
feat: add `chain` to `LightClientPageHelper.getActiveConnections()` response

### DIFF
--- a/packages/light-client-extension-helpers/src/background/smoldot-provider.ts
+++ b/packages/light-client-extension-helpers/src/background/smoldot-provider.ts
@@ -11,7 +11,6 @@ type SmoldotProviderOptions =
       relayChainDatabaseContent?: string
     }
 
-// TODO: check if this needs to use getSyncProvider
 export const smoldotProvider = async ({
   smoldotClient,
   ...options

--- a/packages/light-client-extension-helpers/src/background/types.ts
+++ b/packages/light-client-extension-helpers/src/background/types.ts
@@ -21,7 +21,7 @@ export interface LightClientPageHelper {
   ) => Promise<void>
   getChains: () => Promise<Array<PageChain>>
   getActiveConnections: () => Promise<
-    Array<{ tabId: number; genesisHash: string }>
+    Array<{ tabId: number; chain: PageChain }>
   >
   disconnect: (tabId: number, genesisHash: string) => Promise<void>
   setBootNodes: (genesisHash: string, bootNodes: Array<string>) => Promise<void>
@@ -29,6 +29,8 @@ export interface LightClientPageHelper {
 
 export interface PageChain {
   genesisHash: string
+  chainSpec: string
+  relayChainGenesisHash?: string
   name: string
   ss58Format: number
   bootNodes: Array<string>

--- a/packages/light-client-extension-helpers/src/protocol.ts
+++ b/packages/light-client-extension-helpers/src/protocol.ts
@@ -150,7 +150,17 @@ type BackgroundResponseGetChains = {
 
 type BackgroundResponseGetActiveConnections = {
   type: "getActiveConnectionsResponse"
-  connections: { tabId: number; genesisHash: string }[]
+  connections: {
+    tabId: number
+    chain: {
+      genesisHash: string
+      chainSpec: string
+      relayChainGenesisHash?: string
+      name: string
+      ss58Format: number
+      bootNodes: Array<string>
+    }
+  }[]
 }
 
 type BackgroundResponseDisconnect = {


### PR DESCRIPTION
Replace `genesisHash: string` with `chain: PageChain` in the return type from  `LightClientPageHelper.getActiveConnections()`