### PR TITLE
feat(cli): remove unused symbols from codegen

### DIFF
--- a/packages/rollup-plugin-descriptor-treeshake/package.json
+++ b/packages/rollup-plugin-descriptor-treeshake/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@polkadot-api/rollup-plugin-descriptor-treeshake",
+  "version": "0.0.0",
+  "author": "Víctor Oliva (https://github.com/voliva/)",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/paritytech/polkadot-api.git"
+  },
+  "license": "MIT",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "node": {
+        "production": {
+          "import": "./dist/index.mjs",
+          "require": "./dist/min/index.js",
+          "default": "./dist/index.js"
+        },
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "module": "./dist/index.mjs",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "prebuild": "rimraf -rf dist/*",
+    "build": "rollup -c",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/escodegen": "^0.0.10",
+    "@types/estree": "1.0.1",
+    "@types/node": "^20.9.0",
+    "@typescript-eslint/typescript-estree": "^6.12.0",
+    "rollup": "3.29.4",
+    "rollup-plugin-typescript2": "^0.36.0",
+    "tslib": "^2.6.2",
+    "typescript": "^5.1.6",
+    "vitest": "^0.34.6"
+  },
+  "dependencies": {
+    "estree-walker": "^3.0.3",
+    "magic-string": "^0.30.5",
+    "recast": "^0.23.4"
+  }
+}

--- a/packages/rollup-plugin-descriptor-treeshake/rollup.config.js
+++ b/packages/rollup-plugin-descriptor-treeshake/rollup.config.js
@@ -1,0 +1,19 @@
+import pkg from "./package.json" assert { type: "json" }
+import typescript from "rollup-plugin-typescript2"
+
+/** @type {import('rollup').RollupOptions} */
+const options = {
+  input: "src/index.ts",
+  output: [
+    { file: pkg.main, format: "cjs" },
+    { file: pkg.module, format: "es" },
+  ],
+  plugins: [typescript()],
+  external: [
+    ...Object.keys({ ...pkg.dependencies, ...pkg.peerDependencies }),
+    "fs",
+    "path",
+  ],
+}
+
+export default options

--- a/packages/rollup-plugin-descriptor-treeshake/src/astSymbolTracker.spec.ts
+++ b/packages/rollup-plugin-descriptor-treeshake/src/astSymbolTracker.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, it } from "vitest"
+import { describe, expect, it } from "vitest"
 import { Hooks, astSymbolTracker } from "./astSymbolTracker"
 import { parse } from "@typescript-eslint/typescript-estree"
 
@@ -182,7 +182,7 @@ describe("astSymbolTracker", () => {
     )
   })
 
-  it("can handle simple destructuring", () => {
+  it("can handle destructuring", () => {
     testTrackerFromCode(
       `
       import { tracked } from 'moduleA';
@@ -190,6 +190,7 @@ describe("astSymbolTracker", () => {
       const { memberA: renamed, ...rest } = tracked;
       const { notHappening } = { notHappening: tracked };
       const [ first ] = renamed;
+      const { nested: { property }} = rest;
       `,
       {
         importSymbol: [
@@ -198,6 +199,8 @@ describe("astSymbolTracker", () => {
         memberAccess: [
           ["imported", "memberA", "renamed"],
           ["renamed", "0"],
+          ["imported", "nested", "nested"],
+          ["nested", "property"],
         ],
       },
     )

--- a/packages/rollup-plugin-descriptor-treeshake/src/astSymbolTracker.spec.ts
+++ b/packages/rollup-plugin-descriptor-treeshake/src/astSymbolTracker.spec.ts
@@ -1,0 +1,259 @@
+import { describe, expect, test, it } from "vitest"
+import { Hooks, astSymbolTracker } from "./astSymbolTracker"
+import { parse } from "@typescript-eslint/typescript-estree"
+
+describe("astSymbolTracker", () => {
+  it("notifies of every import", () => {
+    testTrackerFromCode(
+      `
+      import defaultImport, { namedImportA, namedImportB } from 'moduleA'
+      import * as nsImport from 'moduleB'`,
+      {
+        importSymbol: [
+          [0, { type: "default" }, "moduleA"],
+          [0, { type: "named", name: "namedImportA" }, "moduleA"],
+          [0, { type: "named", name: "namedImportB" }, "moduleA"],
+          [1, { type: "namespace" }, "moduleB"],
+        ],
+      },
+    )
+  })
+
+  it("notifies when a tracked function is called", () => {
+    testTrackerFromCode(
+      `
+      import { trackedA, trackedB, notTracked } from 'moduleA';
+
+      trackedB();
+      trackedA(trackedB, notTracked);
+      notTracked();
+      `,
+      {
+        importSymbol: [
+          [0, { type: "named", name: "trackedA" }, "moduleA", "metadataA"],
+          [0, { type: "named", name: "trackedB" }, "moduleA", "metadataB"],
+          [0, { type: "named", name: "notTracked" }, "moduleA"],
+        ],
+        functionCall: [
+          ["metadataB", []],
+          ["metadataA", ["metadataB", null]],
+        ],
+      },
+    )
+  })
+
+  it("notifies when a member of a tracked symbol is accessed", () => {
+    testTrackerFromCode(
+      `
+      import { tracked, notTracked } from 'moduleA';
+
+      tracked.propertyA.propertyB;
+      notTracked.propertyA.propertyB;
+      tracked.propertyA.propertyB;
+      `,
+      {
+        importSymbol: [
+          [0, { type: "named", name: "tracked" }, "moduleA", "imported"],
+          [0, { type: "named", name: "notTracked" }, "moduleA"],
+        ],
+        memberAccess: [
+          ["imported", "propertyA"],
+          ["imported", "propertyA", "metadata"],
+          ["metadata", "propertyB"],
+        ],
+      },
+    )
+  })
+
+  it("notifies of exported tracked symbols", () => {
+    testTrackerFromCode(
+      `
+      import { tracked, notTracked } from 'moduleA';
+
+      const resultA = tracked();
+      export const resultB = tracked.property;
+
+      export { resultA, notTracked };
+      export default resultA;
+      `,
+      {
+        importSymbol: [
+          [0, { type: "named", name: "tracked" }, "moduleA", "imported"],
+          [0, { type: "named", name: "notTracked" }, "moduleA"],
+        ],
+        memberAccess: [["imported", "property", "resultB"]],
+        functionCall: [["imported", [], "resultA"]],
+        exportSymbol: [
+          ["resultB", { type: "named", name: "resultB" }],
+          ["resultA", { type: "named", name: "resultA" }],
+          ["resultA", { type: "default" }],
+        ],
+      },
+    )
+  })
+
+  it("handles nested scopes", () => {
+    testTrackerFromCode(
+      `
+      import { tracked } from 'moduleA';
+
+      {
+        const tracked = "Another value";
+        tracked.toLocaleLowerCase();
+      }
+
+      tracked.trueCall();
+      `,
+      {
+        importSymbol: [
+          [0, { type: "named", name: "tracked" }, "moduleA", "imported"],
+        ],
+        memberAccess: [["imported", "trueCall"]],
+        functionCall: [],
+      },
+    )
+  })
+
+  it("handles reassignments", () => {
+    testTrackerFromCode(
+      `
+      import { tracked } from 'moduleA';
+
+      let tmp = tracked;
+      tmp.first();
+      tmp = "Not now";
+      tmp.second();
+      tmp = tracked;
+      tmp.third();
+      `,
+      {
+        importSymbol: [
+          [0, { type: "named", name: "tracked" }, "moduleA", "imported"],
+        ],
+        memberAccess: [
+          ["imported", "first"],
+          ["imported", "third"],
+        ],
+        functionCall: [],
+      },
+    )
+  })
+
+  it("tracks within complex expressions", () => {
+    testTrackerFromCode(
+      `
+      import { tracked } from 'moduleA';
+
+      const impossible = (() => {
+        return tracked.property;
+      })();
+      `,
+      {
+        importSymbol: [
+          [0, { type: "named", name: "tracked" }, "moduleA", "imported"],
+        ],
+        memberAccess: [["imported", "property"]],
+      },
+    )
+  })
+
+  it("tracks when the code is in reverse order", () => {
+    testTrackerFromCode(
+      `
+      import { tracked } from 'moduleA';
+
+      function functionA() {
+        something.subproperty;
+      }
+      const functionB = () => something()
+
+      const something = tracked.something;
+      `,
+      {
+        importSymbol: [
+          [0, { type: "named", name: "tracked" }, "moduleA", "imported"],
+        ],
+        memberAccess: [
+          ["imported", "something", "something"],
+          ["something", "subproperty"],
+        ],
+        functionCall: [["something", []]],
+      },
+    )
+  })
+
+  it("can handle simple destructuring", () => {
+    testTrackerFromCode(
+      `
+      import { tracked } from 'moduleA';
+
+      const { memberA: renamed, ...rest } = tracked;
+      const { notHappening } = { notHappening: tracked };
+      const [ first ] = renamed;
+      `,
+      {
+        importSymbol: [
+          [0, { type: "named", name: "tracked" }, "moduleA", "imported"],
+        ],
+        memberAccess: [
+          ["imported", "memberA", "renamed"],
+          ["renamed", "0"],
+        ],
+      },
+    )
+  })
+})
+
+type TransformHooks<T> = {
+  [K in keyof T]?: T[K] extends ((...args: infer Args) => any) | undefined
+    ? Array<[...Args, unknown?]>
+    : never
+}
+function testTrackerFromCode(
+  code: string,
+  hooks: TransformHooks<Hooks<unknown>>,
+) {
+  const actualCalls: TransformHooks<Hooks<unknown>> = {
+    exportSymbol: [],
+    functionCall: [],
+    importSymbol: [],
+    memberAccess: [],
+  }
+  const mappedHooks = Object.fromEntries(
+    Object.keys(hooks).map((key) => [
+      key,
+      (...args: unknown[]) => {
+        const typedKey = key as keyof Hooks<unknown>
+        const response =
+          hooks[typedKey]?.[actualCalls[typedKey]!.length]?.[args.length]
+        actualCalls[typedKey]!.push(args as any)
+        return response
+      },
+    ]),
+  )
+
+  astSymbolTracker(parse(code), mappedHooks)
+
+  const lengths = Object.fromEntries(
+    Object.entries(actualCalls).map(([key, value]) => [
+      key,
+      value[0]?.length ?? 1,
+    ]),
+  )
+
+  const expected = {
+    exportSymbol:
+      hooks.exportSymbol?.map((args) => args.slice(0, lengths.exportSymbol)) ??
+      [],
+    functionCall:
+      hooks.functionCall?.map((args) => args.slice(0, lengths.functionCall)) ??
+      [],
+    importSymbol:
+      hooks.importSymbol?.map((args) => args.slice(0, lengths.importSymbol)) ??
+      [],
+    memberAccess:
+      hooks.memberAccess?.map((args) => args.slice(0, lengths.memberAccess)) ??
+      [],
+  }
+  expect(actualCalls).toEqual(expected)
+}

--- a/packages/rollup-plugin-descriptor-treeshake/src/astSymbolTracker.ts
+++ b/packages/rollup-plugin-descriptor-treeshake/src/astSymbolTracker.ts
@@ -1,0 +1,309 @@
+import { walk } from "estree-walker"
+
+import type {
+  AssignmentExpression,
+  CallExpression,
+  ExportDefaultDeclaration,
+  ExportNamedDeclaration,
+  Expression,
+  ImportDeclaration,
+  MemberExpression,
+  Node,
+  VariableDeclaration,
+} from "estree"
+
+export type ImportedSymbol =
+  | {
+      type: "named"
+      name: string
+    }
+  | {
+      type: "namespace" | "default"
+    }
+export type ExportedSymbol =
+  | { type: "named"; name: string }
+  | { type: "default" }
+
+export interface Hooks<T> {
+  importSymbol?: (
+    index: number,
+    imported: ImportedSymbol,
+    file: string,
+  ) => T | null | void
+  memberAccess?: (symbol: T, property: string) => T | null | void
+  functionCall?: (symbol: T, args: Array<T | null>) => T | null | void
+  exportSymbol?: (symbol: T, exported: ExportedSymbol) => void
+}
+
+/**
+ * AST symbolTracker
+ *
+ * -> Given a list of symbols defined in the root scope, lets you track their usage.
+ * -> Features
+ *  -> Member access: client.qt.Pallet1.baz.methodA() => client.qt.Pallet1.baz.methodA
+ *  -> Function calls: client.qt.Pallet1.baz.methodA(), createClient(descriptor)
+ *  -> Notify when creating a new variable, lets you keep tracking it: const client = createClient(descriptor);
+ *  -> Notify on import, lets you track it.
+ *  -> Notify on dynamic import, lets you track it.
+ *  -> Which ones are exported
+ */
+
+export function astSymbolTracker<T>(rootAst: Node, hooks: Hooks<T>) {
+  const scope = new Scope<T>()
+
+  let importIndex = 0
+  const readImportDeclaration = (root: ImportDeclaration) => {
+    const file = String(root.source.value)
+    root.specifiers.forEach((specifier) => {
+      const name = specifier.local.name
+      const importedSymbol = ((): ImportedSymbol => {
+        switch (specifier.type) {
+          case "ImportDefaultSpecifier":
+            return { type: "default" }
+          case "ImportNamespaceSpecifier":
+            return { type: "namespace" }
+          case "ImportSpecifier":
+            return { type: "named", name: specifier.imported.name }
+        }
+      })()
+      const metadata = hooks.importSymbol?.(importIndex, importedSymbol, file)
+      if (metadata) {
+        scope.set(name, metadata)
+      }
+    })
+    importIndex++
+  }
+  const resolveExpression = (expression: Expression | Node) => {
+    switch (expression.type) {
+      case "MemberExpression":
+        return readMemberExpression(expression)
+      case "Identifier":
+        return scope.get(expression.name)
+      case "CallExpression":
+        return readCallExpression(expression)
+    }
+    // For other types we don't support we will return null, but we still need
+    // to go through the ast to find other used tracked symbols
+    // e.g. `const someFunction = () => client.has.to.be.tracked;
+    walkRoot(expression)
+    return null
+  }
+  const readMemberExpression = (root: MemberExpression): T | null => {
+    const property = root.property
+    // property can also be an expression, such as in foo[1+2] foo["bar"] foo[something ? "bar" : "baz"]
+    // In that case we can't track it
+    // TODO bail out from tree shaking ?
+    // TODO give opportunity to keep tracking with metadata
+    if (property.type !== "Identifier") return null
+
+    const symbol = resolveExpression(root.object)
+    if (!symbol) return null
+
+    return hooks.memberAccess?.(symbol, property.name) ?? null
+  }
+  const readCallExpression = (root: CallExpression): T | null => {
+    const callee = resolveExpression(root.callee)
+    if (!callee) return null
+
+    const fnArgs = root.arguments.map((expression) =>
+      resolveExpression(expression),
+    )
+
+    return hooks.functionCall?.(callee, fnArgs) ?? null
+  }
+  const readVariableDeclaration = (
+    root: VariableDeclaration,
+  ): Record<string, T | null> => {
+    // We're returning an object with all the variables we have detected
+    return Object.fromEntries(
+      root.declarations
+        .map((declarator) => {
+          // `init` is the expression on the right-hand-side: We grab that value.
+          const value = declarator.init
+            ? resolveExpression(declarator.init)
+            : null
+
+          // Declarator is left-hand-side. Simplest case is an identifier
+          if (declarator.id.type === "Identifier") {
+            scope.set(declarator.id.name, value)
+            return [declarator.id.name, value]
+          }
+
+          // Going for simple case of `const { property } = tracked`
+          // TODO nested access `const { property: { subproperty }} = tracked`;
+          if (declarator.id.type === "ObjectPattern") {
+            return declarator.id.properties.map((property) => {
+              if (
+                property.type === "Property" &&
+                property.key.type === "Identifier" &&
+                property.value.type === "Identifier"
+              ) {
+                if (value) {
+                  const tracked =
+                    hooks.memberAccess?.(value, property.key.name) ?? null
+                  scope.set(property.value.name, tracked)
+                  return [property.value.name, tracked]
+                }
+                scope.set(property.value.name, null)
+              }
+              return null
+            })
+          }
+          if (declarator.id.type === "ArrayPattern") {
+            return declarator.id.elements.map((element, idx) => {
+              if (element?.type === "Identifier") {
+                if (value) {
+                  const tracked =
+                    hooks.memberAccess?.(value, String(idx)) ?? null
+                  scope.set(element.name, tracked)
+                }
+                scope.set(element.name, null)
+              }
+              return null
+            })
+          }
+          // TODO other pattern assignment
+
+          // As we don't have a name on left-hand-side, we have to discard it: return null and filter out.
+          return null!
+        })
+        .filter(Boolean),
+    )
+  }
+  const readExportNamedDeclaration = (root: ExportNamedDeclaration) => {
+    if (root.declaration) {
+      // e.g. `export const result = { /* ... */ }`
+      // Declaration can be variable, function or class. We only care about variables
+      if (root.declaration.type !== "VariableDeclaration") return
+
+      const variables = readVariableDeclaration(root.declaration)
+      Object.entries(variables).forEach(([name, symbol]) => {
+        if (!symbol) return
+        hooks.exportSymbol?.(symbol, { type: "named", name })
+      })
+    }
+    // Specifiers is for the case `export { result, client as bestClient }`
+    root.specifiers.forEach((specifier) => {
+      const symbol = scope.get(specifier.local.name)
+      if (symbol) {
+        hooks.exportSymbol?.(symbol, {
+          type: "named",
+          name: specifier.exported.name,
+        })
+      }
+    })
+  }
+  const readExportDefaultDeclaration = (root: ExportDefaultDeclaration) => {
+    // `export default class Something {}` and `export default function something() {}`
+    // will never be tracked
+    if (
+      root.declaration.type === "ClassDeclaration" ||
+      root.declaration.type === "FunctionDeclaration"
+    )
+      return
+
+    const symbol = resolveExpression(root.declaration)
+    if (symbol) {
+      hooks.exportSymbol?.(symbol, { type: "default" })
+    }
+  }
+  const readAssignmentExpression = (root: AssignmentExpression) => {
+    const right = resolveExpression(root.right)
+    // TODO pattern assignment
+    if (root.left.type !== "Identifier") return null!
+    scope.set(root.left.name, right)
+  }
+
+  // Functions can reference variables that are defined after the function. It's better if we read them after that.
+  const hoisted: Node[] = []
+
+  // Into a separate function since we can restart the walk from a sub-node
+  const walkRoot = (root: Node, secondPass = false) => {
+    walk(root, {
+      enter(node) {
+        switch (node.type) {
+          case "ImportDeclaration":
+            readImportDeclaration(node)
+            this.skip()
+            break
+          case "MemberExpression":
+            readMemberExpression(node)
+            this.skip()
+            break
+          case "CallExpression":
+            readCallExpression(node)
+            this.skip()
+            break
+          case "VariableDeclaration":
+            readVariableDeclaration(node)
+            this.skip()
+            break
+          case "AssignmentExpression":
+            readAssignmentExpression(node)
+            this.skip()
+            break
+          case "ExportNamedDeclaration":
+            readExportNamedDeclaration(node)
+            this.skip()
+            break
+          case "ExportDefaultDeclaration":
+            readExportDefaultDeclaration(node)
+            this.skip()
+            break
+          case "FunctionDeclaration":
+          case "ArrowFunctionExpression":
+            if (!secondPass || node !== root) {
+              hoisted.push(node)
+              this.skip()
+            }
+            break
+          case "BlockStatement":
+            scope.push()
+          // default:
+          //   console.log(node);
+        }
+      },
+      leave(node) {
+        if (node.type === "BlockStatement") {
+          scope.pop()
+        }
+      },
+    })
+  }
+
+  walkRoot(rootAst)
+  while (hoisted.length) {
+    walkRoot(hoisted.pop()!, true)
+  }
+}
+
+class Scope<T> {
+  private stack: Array<Record<string, T | null>> = [{}]
+
+  push() {
+    this.stack.push({})
+  }
+  pop() {
+    this.stack.pop()
+  }
+  set(name: string, value: T | null) {
+    this.stack[this.stack.length - 1][name] = value
+  }
+  get(name: string) {
+    for (let i = this.stack.length - 1; i >= 0; i--) {
+      if (name in this.stack[i]) {
+        return this.stack[i][name]
+      }
+    }
+    return null
+  }
+  replace(name: string, value: T | null) {
+    for (let i = this.stack.length - 1; i > 0; i--) {
+      if (name in this.stack[i]) {
+        this.stack[i][name] = value
+        return
+      }
+    }
+    this.stack[0][name] = value
+  }
+}

--- a/packages/rollup-plugin-descriptor-treeshake/src/index.ts
+++ b/packages/rollup-plugin-descriptor-treeshake/src/index.ts
@@ -1,0 +1,306 @@
+import recast from "recast"
+import MagicString from "magic-string"
+import type { Node } from "estree"
+import fs from "fs"
+import path from "path"
+import type { ModuleInfo, Plugin } from "rollup"
+import { astSymbolTracker } from "./astSymbolTracker"
+import { applyWhitelist } from "./whitelist"
+
+const DEFAULT = Symbol("default")
+type DEFAULT = typeof DEFAULT
+
+export default function descriptorTreeShake(codegenFolder: string): Plugin {
+  let codegenFiles: string[] = []
+  let pApiClient: string = ""
+
+  const entryPoints: string[] = []
+  let detectedPaths: Paths = {}
+
+  return {
+    name: "descriptorTreeShake",
+    async buildStart() {
+      // Reset state
+      entryPoints.length = 0
+      detectedPaths = {}
+
+      // On build start we resolve the ids of the entry files: polkadot-api and
+      // generated code.
+      const files = await new Promise<string[]>((resolve, reject) => {
+        fs.readdir(codegenFolder, (err, files) => {
+          if (err) return reject(err)
+          resolve(
+            files
+              .filter((file) => !file.endsWith(".d.ts") && file.endsWith(".ts"))
+              .map((name) => path.join(codegenFolder, name)),
+          )
+        })
+      })
+      const resolved = await Promise.all(
+        files.map((file) => this.resolve(file)),
+      )
+      codegenFiles = resolved.filter(Boolean).map((result) => result!.id)
+
+      const papiClientResolution = await this.resolve("@polkadot-api/client")
+      if (!papiClientResolution) {
+        throw new Error("Can't find module @polkadot-api/client")
+      }
+      pApiClient = papiClientResolution.id
+    },
+    moduleParsed(moduleInfo: ModuleInfo) {
+      // If the module is importing one of the entry files, it's marked as an entry point.
+      if (
+        codegenFiles.some((id) => moduleInfo.importedIds.includes(id)) ||
+        moduleInfo.importedIds.includes(pApiClient)
+      ) {
+        entryPoints.push(moduleInfo.id)
+      }
+    },
+    buildEnd() {
+      type SymbolMetadata =
+        | { type: "clientNamespace" | "createClientSymbol" }
+        | { type: "generatedSymbol" | "clientSymbol"; file: string }
+        | { type: "path"; file: string; path: string[] }
+      type Exports = Partial<Record<string | DEFAULT, SymbolMetadata>>
+      type ImportMetadata =
+        | {
+            type: "client"
+          }
+        | {
+            type: "generated"
+            file: string
+          }
+        | {
+            type: "external"
+            exports: Exports
+          }
+
+      // Map from moduleId to the interesting symbols it's exporting
+      const resolvedExports: Record<string, Exports> = {}
+
+      // Traverse one file by moduleId. Returns the paths to be whitelisted
+      // and the list of modules that import it if it's exporting something interesting
+      const traverse = (
+        id: string,
+      ): {
+        paths: Paths
+        importers: readonly string[]
+      } => {
+        const root = this.getModuleInfo(id)
+        if (!root) {
+          throw new Error(`Module "${id}" not found`)
+        }
+        if (!root.ast) {
+          return {
+            paths: {},
+            importers: [],
+          }
+        }
+
+        const result = readAst(
+          root.ast as Node,
+          // We're passing in the list of imports as resolved by Rollup.
+          // TODO better way of doing this? Problem is ast doesn't have names
+          // resolved, so we have to rely on import order.
+          root.importedIdResolutions.map(
+            (resolution): ImportMetadata | null => {
+              if (resolution.id === pApiClient) {
+                return {
+                  type: "client",
+                }
+              }
+              if (codegenFiles.some((id) => id === resolution.id)) {
+                return {
+                  type: "generated",
+                  file: resolution.id,
+                }
+              }
+              if (resolvedExports[resolution.id]) {
+                return {
+                  type: "external",
+                  exports: resolvedExports[resolution.id],
+                }
+              }
+              return null
+            },
+          ),
+        )
+
+        resolvedExports[id] = {
+          ...(resolvedExports[id] ?? {}),
+          ...result.exports,
+        }
+
+        return {
+          paths: result.paths,
+          importers: Object.keys(result.exports).length ? root.importers : [],
+        }
+      }
+
+      // Read the AST of a root file, and return the detected paths and exports.
+      const readAst = (
+        rootAst: Node,
+        importMetadata: Array<ImportMetadata | null>,
+      ) => {
+        const paths: Paths = {}
+        const exports: Exports = {}
+        astSymbolTracker<SymbolMetadata>(rootAst, {
+          importSymbol(index, imported) {
+            // Plugin would allow us to re-resolve the import name, but it's async.
+            // need to benchmark implications of this
+            // pluginCtx
+            //   .resolve(file, id)
+            //   .then((r) => console.log(file, "resolved", r));
+
+            const importMeta = importMetadata[index]
+            if (!importMeta) return null
+
+            switch (importMeta.type) {
+              case "client":
+                // e.g. import * as pApiClient from '@polkadot-api/client'
+                if (imported.type === "namespace") {
+                  return {
+                    type: "clientNamespace",
+                  }
+                }
+                // e.g. import { createClient } from '@polkadot-api/client'
+                if (
+                  imported.type === "named" &&
+                  imported.name === "createClient"
+                ) {
+                  return {
+                    type: "createClientSymbol",
+                  }
+                }
+                return null
+              case "generated":
+                // We only care about default import here
+                // e.g. import descriptors from "./codegen/test"
+                if (imported.type === "default") {
+                  return {
+                    type: "generatedSymbol",
+                    file: importMeta.file,
+                  }
+                }
+                return null
+              case "external":
+                // This import is from a file we have already parsed and know
+                // which "interesting" symbols is exporting.
+                if (imported.type === "default") {
+                  return importMeta.exports[DEFAULT] ?? null
+                } else if (imported.type === "named") {
+                  return importMeta.exports[imported.name] ?? null
+                } else {
+                  // TODO namespace
+                  // similar case to `const somethingNested = { client }; somethingNested.client.tx.aa`
+                  return null
+                }
+            }
+          },
+          memberAccess(symbol, property) {
+            switch (symbol.type) {
+              case "clientNamespace":
+                // e.g. pApiClient.createClient
+                return property === "createClient"
+                  ? { type: "createClientSymbol" }
+                  : null
+              case "clientSymbol":
+                // It's using the client, accessing the first prop
+                // e.g. client.tx
+                return { type: "path", file: symbol.file, path: [property] }
+              case "path":
+                // Any other subproperty
+                // e.g. `client.tx.Pallet` => path: ['tx'], property: 'Pallet'
+                if (symbol.path.length === 2) {
+                  paths[symbol.file] = paths[symbol.file] ?? new Set()
+                  paths[symbol.file].add([...symbol.path, property].join("."))
+                  return null
+                }
+                return { ...symbol, path: [...symbol.path, property] }
+            }
+            return null
+          },
+          functionCall(symbol, args) {
+            if (symbol.type !== "createClientSymbol") return null
+            // e.g. createClient(chain, descriptors)
+            const arg = args[1]
+            if (!arg || arg.type !== "generatedSymbol") {
+              // TODO graceful exit: warn and bail out from treeshaking
+              throw new Error("Can't know which generated code it's using")
+            }
+            return {
+              type: "clientSymbol",
+              file: arg.file,
+            }
+          },
+          exportSymbol(symbol, exported) {
+            exports[exported.type === "default" ? DEFAULT : exported.name] =
+              symbol
+          },
+        })
+
+        return { paths, exports }
+      }
+
+      const filesToTraverse = new Set(entryPoints)
+      const paths: Paths[] = []
+      // filesToTraverse can grow as we're exploring and symbols are getting
+      // exported and imported into other files.
+      while (filesToTraverse.size) {
+        const id = shiftSet(filesToTraverse)!
+        const result = traverse(id)
+        paths.push(result.paths)
+        result.importers.forEach((id) => filesToTraverse.add(id))
+      }
+      detectedPaths = mergePaths(paths)
+    },
+    renderChunk(code, chunk) {
+      // It would be better to do code transformations on `transform` hook, but
+      // at that point we don't have all modules resolved and parsed. After
+      // buildEnd hook, the only place we can do transforms are in `renderChunk`
+      // In here we remove the unused paths.
+      const modifications = Object.entries(detectedPaths)
+        .map(([id, whitelist]) => {
+          const targetModule = chunk.modules[id]
+          if (!targetModule?.code) return null!
+
+          const ast = recast.parse(targetModule.code)
+          applyWhitelist(ast as Node, whitelist)
+          const result = recast.print(ast)
+
+          return [targetModule.code, result.code] as const
+        })
+        .filter(Boolean)
+
+      if (!modifications.length) return null
+
+      const codeMs = new MagicString(code)
+      modifications.forEach(([oldCode, newCode]) => {
+        codeMs.replace(oldCode, newCode)
+      })
+
+      return {
+        code: codeMs.toString(),
+        map: codeMs.generateMap({}),
+      }
+    },
+  }
+}
+
+type Paths = Record<string, Set<string>>
+function mergePaths(paths: Array<Paths>) {
+  return paths.reduce((acc, paths) => {
+    Object.entries(paths).forEach(([id, pathSet]) => {
+      acc[id] = acc[id] ? new Set([...acc[id], ...pathSet]) : pathSet
+    })
+    return acc
+  }, {} as Paths)
+}
+
+function shiftSet<T>(set: Set<T>) {
+  for (const value of set) {
+    set.delete(value)
+    return value
+  }
+  return
+}

--- a/packages/rollup-plugin-descriptor-treeshake/src/whitelist.ts
+++ b/packages/rollup-plugin-descriptor-treeshake/src/whitelist.ts
@@ -1,0 +1,125 @@
+import type { ObjectExpression, Node } from "estree"
+import { walk } from "estree-walker"
+
+export function applyWhitelist(root: Node, whitelist: Set<string>) {
+  const constNames = [...whitelist].map(pathToConst)
+
+  walk(root, {
+    enter(node) {
+      if (node.type === "VariableDeclarator" && node.id.type === "Identifier") {
+        if (node.id.name === "_allDescriptors") {
+          applyWhitelistToDescriptor(node.init as ObjectExpression, whitelist)
+          this.skip()
+        } else if (
+          !constNames.includes(node.id.name) &&
+          node.init?.type === "Literal"
+        ) {
+          // Removing statements of shape `const TxPalletmethod = "hash"`;
+          this.remove()
+        }
+      }
+    },
+    leave(node) {
+      // The `this.remove()` removing the constant above left its parent VariableDeclaration
+      // with no declarations, resulting in an invalid AST, e.g. `const ?? ??`.
+      // We also need to remove the VariableDeclaration when this happens.
+      if (
+        node.type === "VariableDeclaration" &&
+        node.declarations.length === 0
+      ) {
+        this.remove()
+      }
+    },
+  })
+}
+
+function applyWhitelistToDescriptor(
+  root: ObjectExpression,
+  whitelist: Set<string>,
+) {
+  // [pallet, idx]
+  const currentPath: string[] = []
+  const idxToProp = ["query", "tx", "event", "error", "const"]
+  let idx = 0
+
+  walk(root, {
+    enter(node) {
+      switch (currentPath.length) {
+        case 0:
+          if (node.type === "Property" && node.key.type === "Identifier") {
+            // Push pallet
+            currentPath.push(node.key.name)
+            idx = 0
+          }
+          break
+        case 1:
+          if (node.type === "ObjectExpression") {
+            // Push idx
+            currentPath.push(idxToProp[idx])
+            idx++
+          }
+          break
+        case 2:
+          if (node.type === "Property" && node.key.type === "Identifier") {
+            // Remove property from objet if it's not in the whitelist.
+            const [pallet, prop] = currentPath
+            if (!whitelist.has([prop, pallet, node.key.name].join("."))) {
+              this.remove()
+            }
+          }
+          break
+      }
+    },
+    leave(node) {
+      switch (currentPath.length) {
+        case 1:
+          if (node.type === "Property") {
+            // Pop out from pallet
+            currentPath.pop()
+          }
+          break
+        case 2:
+          if (node.type === "ObjectExpression") {
+            // Pop out from prop
+            currentPath.pop()
+          }
+          break
+      }
+
+      // Remove empty pallets: `{ Pallet: [{},{},{},{},{}] }`
+      if (node.type === "ArrayExpression") {
+        if (
+          node.elements.every(
+            (element) =>
+              element?.type === "ObjectExpression" &&
+              element.properties.length === 0,
+          )
+        ) {
+          this.remove()
+        }
+      } else if (node.type === "ObjectExpression") {
+        // The removal of empty pallets can leave objects with properties
+        // without value, leaving an invalid AST: `{ Pallet: ?? }`
+        // We also need to remove the property to leave it valid.
+        node.properties = node.properties.filter((prop) => {
+          if (prop.type === "Property" && !prop.value) {
+            return false
+          }
+          return true
+        })
+      }
+    },
+  })
+}
+const pathToConst = (path: string) => {
+  const [op, pallet, method] = path.split(".")
+
+  return opToConst[op] + pallet + method
+}
+const opToConst: Record<string, string> = {
+  query: "Stg",
+  tx: "Tx",
+  event: "Ev",
+  error: "Err",
+  const: "Const",
+}

--- a/packages/rollup-plugin-descriptor-treeshake/tsconfig.json
+++ b/packages/rollup-plugin-descriptor-treeshake/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base",
+  "include": ["src"],
+  "exclude": ["**/*.spec.ts"],
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "types": ["node"]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -470,6 +470,46 @@ importers:
         specifier: ^0.34.3
         version: 0.34.4(vitest@0.34.6)
 
+  packages/rollup-plugin-descriptor-treeshake:
+    dependencies:
+      estree-walker:
+        specifier: ^3.0.3
+        version: 3.0.3
+      magic-string:
+        specifier: ^0.30.5
+        version: 0.30.5
+      recast:
+        specifier: ^0.23.4
+        version: 0.23.4
+    devDependencies:
+      '@types/escodegen':
+        specifier: ^0.0.10
+        version: 0.0.10
+      '@types/estree':
+        specifier: 1.0.1
+        version: 1.0.1
+      '@types/node':
+        specifier: ^20.9.0
+        version: 20.9.0
+      '@typescript-eslint/typescript-estree':
+        specifier: ^6.12.0
+        version: 6.12.0(typescript@5.2.2)
+      rollup:
+        specifier: 3.29.4
+        version: 3.29.4
+      rollup-plugin-typescript2:
+        specifier: ^0.36.0
+        version: 0.36.0(rollup@3.29.4)(typescript@5.2.2)
+      tslib:
+        specifier: ^2.6.2
+        version: 2.6.2
+      typescript:
+        specifier: ^5.1.6
+        version: 5.2.2
+      vitest:
+        specifier: ^0.34.6
+        version: 0.34.6
+
   packages/sc-provider:
     dependencies:
       '@polkadot-api/json-rpc-provider-proxy':
@@ -589,6 +629,9 @@ importers:
         specifier: ^7.8.1
         version: 7.8.1
     devDependencies:
+      '@polkadot-api/rollup-plugin-descriptor-treeshake':
+        specifier: workspace:*
+        version: link:../packages/rollup-plugin-descriptor-treeshake
       '@types/node':
         specifier: ^20.4.1
         version: 20.9.0
@@ -2678,7 +2721,6 @@ packages:
 
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-    dev: true
 
   /@jridgewell/trace-mapping@0.3.19:
     resolution: {integrity: sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==}
@@ -3789,6 +3831,14 @@ packages:
       '@babel/runtime': 7.21.0
     dev: true
 
+  /@rollup/pluginutils@4.2.1:
+    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
+    engines: {node: '>= 8.0.0'}
+    dependencies:
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+    dev: true
+
   /@rollup/pluginutils@5.0.5:
     resolution: {integrity: sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==}
     engines: {node: '>=14.0.0'}
@@ -3947,7 +3997,7 @@ packages:
       '@storybook/react-dom-shim': 7.5.3(react-dom@18.2.0)(react@18.2.0)
       '@storybook/theming': 7.5.3(react-dom@18.2.0)(react@18.2.0)
       '@storybook/types': 7.5.3
-      fs-extra: 11.1.0
+      fs-extra: 11.1.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       remark-external-links: 8.0.0
@@ -4226,7 +4276,7 @@ packages:
       esbuild-plugin-alias: 0.2.1
       express: 4.18.2
       find-cache-dir: 3.3.2
-      fs-extra: 11.1.0
+      fs-extra: 11.1.1
       process: 0.11.10
       util: 0.12.5
     transitivePeerDependencies:
@@ -4262,7 +4312,7 @@ packages:
       es-module-lexer: 0.9.3
       express: 4.18.2
       find-cache-dir: 3.3.2
-      fs-extra: 11.1.0
+      fs-extra: 11.1.1
       magic-string: 0.30.5
       rollup: 3.29.4
       typescript: 5.2.2
@@ -4310,7 +4360,7 @@ packages:
       execa: 5.1.1
       express: 4.18.2
       find-up: 5.0.0
-      fs-extra: 11.1.0
+      fs-extra: 11.1.1
       get-npm-tarball-url: 2.1.0
       get-port: 5.1.1
       giget: 1.1.3
@@ -4408,7 +4458,7 @@ packages:
       file-system-cache: 2.3.0
       find-cache-dir: 3.3.2
       find-up: 5.0.0
-      fs-extra: 11.1.0
+      fs-extra: 11.1.1
       glob: 10.3.4
       handlebars: 4.7.8
       lazy-universal-dotenv: 4.0.0
@@ -4457,7 +4507,7 @@ packages:
       compression: 1.7.4
       detect-port: 1.5.1
       express: 4.18.2
-      fs-extra: 11.1.0
+      fs-extra: 11.1.1
       globby: 11.1.0
       ip: 2.0.0
       lodash: 4.17.21
@@ -4498,7 +4548,7 @@ packages:
       '@babel/types': 7.23.4
       '@storybook/csf': 0.1.1
       '@storybook/types': 7.5.3
-      fs-extra: 11.1.0
+      fs-extra: 11.1.1
       recast: 0.23.4
       ts-dedent: 2.2.0
     transitivePeerDependencies:
@@ -4706,7 +4756,7 @@ packages:
       chalk: 4.1.2
       detect-package-manager: 2.0.1
       fetch-retry: 5.0.6
-      fs-extra: 11.1.0
+      fs-extra: 11.1.1
       read-pkg-up: 7.0.1
     transitivePeerDependencies:
       - encoding
@@ -5039,6 +5089,10 @@ packages:
     resolution: {integrity: sha512-TB/6hBkYQJxsZHSqyeuO1Jt0AB/bW6G7rHt9g7lML7SOF6lbgcHvw/Lr+69iqN0qxgXLhWKScAon73JNnptuDw==}
     dev: true
 
+  /@types/escodegen@0.0.10:
+    resolution: {integrity: sha512-IVvcNLEFbiL17qiGRGzyfx/u9K6lA5w6wcQSIgv2h4JG3ZAFIY1Be9ITTSPuARIxRpzW54s8OvcF6PdonBbDzg==}
+    dev: true
+
   /@types/escodegen@0.0.6:
     resolution: {integrity: sha512-AjwI4MvWx3HAOaZqYsjKWyEObT9lcVV0Y0V8nXo6cXzN8ZiMxVhf6F3d/UNvXVGKrEzL/Dluc5p+y9GkzlTWig==}
     dev: true
@@ -5343,9 +5397,35 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@typescript-eslint/types@6.12.0:
+    resolution: {integrity: sha512-MA16p/+WxM5JG/F3RTpRIcuOghWO30//VEOvzubM8zuOOBYXsP+IfjoCXXiIfy2Ta8FRh9+IO9QLlaFQUU+10Q==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dev: true
+
   /@typescript-eslint/types@6.7.2:
     resolution: {integrity: sha512-flJYwMYgnUNDAN9/GAI3l8+wTmvTYdv64fcH8aoJK76Y+1FCZ08RtI5zDerM/FYT5DMkAc+19E4aLmd5KqdFyg==}
     engines: {node: ^16.0.0 || >=18.0.0}
+
+  /@typescript-eslint/typescript-estree@6.12.0(typescript@5.2.2):
+    resolution: {integrity: sha512-vw9E2P9+3UUWzhgjyyVczLWxZ3GuQNT7QpnIY3o5OMeLO/c8oHljGc8ZpryBMIyympiAAaKgw9e5Hl9dCWFOYw==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 6.12.0
+      '@typescript-eslint/visitor-keys': 6.12.0
+      debug: 4.3.4(supports-color@9.4.0)
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.4
+      ts-api-utils: 1.0.3(typescript@5.2.2)
+      typescript: 5.2.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@typescript-eslint/typescript-estree@6.7.2(typescript@5.2.2):
     resolution: {integrity: sha512-kiJKVMLkoSciGyFU0TOY0fRxnp9qq1AzVOHNeN1+B9erKFCJ4Z8WdjAkKQPP+b1pWStGFqezMLltxO+308dJTQ==}
@@ -5384,6 +5464,14 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  /@typescript-eslint/visitor-keys@6.12.0:
+    resolution: {integrity: sha512-rg3BizTZHF1k3ipn8gfrzDXXSFKyOEB5zxYXInQ6z0hUvmQlhaZQzK+YmHmNViMA9HzW5Q9+bPPt90bU6GQwyw==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.12.0
+      eslint-visitor-keys: 3.4.3
+    dev: true
 
   /@typescript-eslint/visitor-keys@6.7.2:
     resolution: {integrity: sha512-uVw9VIMFBUTz8rIeaUT3fFe8xIUx8r4ywAdlQv1ifH+6acn/XF8Y6rwJ7XNmkNMDrTW+7+vxFFPIF40nJCVsMQ==}
@@ -5840,7 +5928,6 @@ packages:
       object-is: 1.1.5
       object.assign: 4.1.4
       util: 0.12.5
-    dev: true
 
   /assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
@@ -5858,7 +5945,6 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       tslib: 2.6.2
-    dev: true
 
   /astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -5890,7 +5976,6 @@ packages:
   /available-typed-arrays@1.0.5:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /aws-sign2@0.7.0:
     resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
@@ -6203,7 +6288,6 @@ packages:
       function-bind: 1.1.2
       get-intrinsic: 1.2.2
       set-function-length: 1.1.1
-    dev: true
 
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -6820,7 +6904,6 @@ packages:
       get-intrinsic: 1.2.2
       gopd: 1.0.1
       has-property-descriptors: 1.0.1
-    dev: true
 
   /define-lazy-prop@2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
@@ -6839,7 +6922,6 @@ packages:
       define-data-property: 1.1.1
       has-property-descriptors: 1.0.1
       object-keys: 1.1.1
-    dev: true
 
   /defu@6.1.3:
     resolution: {integrity: sha512-Vy2wmG3NTkmHNg/kzpuvHhkqeIx3ODWqasgCRbKtbXEN0G+HpEEv9BtJLp7ZG1CZloFaC41Ah3ZFbq7aqCqMeQ==}
@@ -7387,7 +7469,6 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
 
   /esquery@1.5.0:
     resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
@@ -7408,6 +7489,12 @@ packages:
   /estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
     dev: true
+
+  /estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    dependencies:
+      '@types/estree': 1.0.1
+    dev: false
 
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
@@ -7764,7 +7851,6 @@ packages:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
     dependencies:
       is-callable: 1.2.7
-    dev: true
 
   /foreground-child@3.1.1:
     resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
@@ -7843,6 +7929,15 @@ packages:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
     dev: true
 
+  /fs-extra@10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.0
+    dev: true
+
   /fs-extra@11.1.0:
     resolution: {integrity: sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==}
     engines: {node: '>=14.14'}
@@ -7906,7 +8001,6 @@ packages:
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-    dev: true
 
   /functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
@@ -7945,7 +8039,6 @@ packages:
       has-proto: 1.0.1
       has-symbols: 1.0.3
       hasown: 2.0.0
-    dev: true
 
   /get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
@@ -8123,7 +8216,6 @@ packages:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
       get-intrinsic: 1.2.2
-    dev: true
 
   /got@12.6.1:
     resolution: {integrity: sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==}
@@ -8216,24 +8308,20 @@ packages:
     resolution: {integrity: sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==}
     dependencies:
       get-intrinsic: 1.2.2
-    dev: true
 
   /has-proto@1.0.1:
     resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /has-symbols@1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /has-tostringtag@1.0.0:
     resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
-    dev: true
 
   /has-yarn@3.0.0:
     resolution: {integrity: sha512-IrsVwUHhEULx3R8f/aA8AHuEzAorplsab/v8HBzEiIukwq5i/EC+xmOW+HfP1OaDP+2JkgT1yILHN2O3UFIbcA==}
@@ -8255,7 +8343,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
-    dev: true
 
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -8487,7 +8574,6 @@ packages:
     dependencies:
       call-bind: 1.0.5
       has-tostringtag: 1.0.0
-    dev: true
 
   /is-array-buffer@3.0.2:
     resolution: {integrity: sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==}
@@ -8524,7 +8610,6 @@ packages:
   /is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /is-ci@3.0.1:
     resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
@@ -8578,7 +8663,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-tostringtag: 1.0.0
-    dev: true
 
   /is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -8631,7 +8715,6 @@ packages:
     dependencies:
       call-bind: 1.0.5
       define-properties: 1.2.1
-    dev: true
 
   /is-npm@6.0.0:
     resolution: {integrity: sha512-JEjxbSmtPSt1c8XTkVrlujcXdKV1/tvuQ7GwKcAlyiVLeYFQ2VHat8xfrDJsIkhCdF/tZ7CiIR3sy141c6+gPQ==}
@@ -8735,7 +8818,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       which-typed-array: 1.1.13
-    dev: true
 
   /is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
@@ -9054,7 +9136,7 @@ packages:
     dependencies:
       jws: 3.2.2
       lodash: 4.17.21
-      ms: 2.1.2
+      ms: 2.1.3
       semver: 7.5.4
     dev: true
 
@@ -9343,7 +9425,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
 
   /make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -9833,12 +9914,10 @@ packages:
     dependencies:
       call-bind: 1.0.5
       define-properties: 1.2.1
-    dev: true
 
   /object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /object.assign@4.1.4:
     resolution: {integrity: sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==}
@@ -9848,7 +9927,6 @@ packages:
       define-properties: 1.2.1
       has-symbols: 1.0.3
       object-keys: 1.1.1
-    dev: true
 
   /on-exit-leak-free@2.1.0:
     resolution: {integrity: sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w==}
@@ -10857,7 +10935,6 @@ packages:
       esprima: 4.0.1
       source-map: 0.6.1
       tslib: 2.6.2
-    dev: true
 
   /regenerate-unicode-properties@10.1.1:
     resolution: {integrity: sha512-X007RyZLsCJVVrjgEFVpLUTZwyOZk3oiL75ZcuYjlIWd6rNJtOjkBwQc5AsRrpbKVkxN6sklw/k/9m2jJYOf8Q==}
@@ -11067,6 +11144,21 @@ packages:
     dependencies:
       glob: 7.1.6
 
+  /rollup-plugin-typescript2@0.36.0(rollup@3.29.4)(typescript@5.2.2):
+    resolution: {integrity: sha512-NB2CSQDxSe9+Oe2ahZbf+B4bh7pHwjV5L+RSYpCu7Q5ROuN94F9b6ioWwKfz3ueL3KTtmX4o2MUH2cgHDIEUsw==}
+    peerDependencies:
+      rollup: '>=1.26.3'
+      typescript: '>=2.4.0'
+    dependencies:
+      '@rollup/pluginutils': 4.2.1
+      find-cache-dir: 3.3.2
+      fs-extra: 10.1.0
+      rollup: 3.29.4
+      semver: 7.5.4
+      tslib: 2.6.2
+      typescript: 5.2.2
+    dev: true
+
   /rollup@3.29.4:
     resolution: {integrity: sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
@@ -11206,7 +11298,6 @@ packages:
       get-intrinsic: 1.2.2
       gopd: 1.0.1
       has-property-descriptors: 1.0.1
-    dev: true
 
   /set-function-name@2.0.1:
     resolution: {integrity: sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==}
@@ -11396,7 +11487,6 @@ packages:
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
@@ -12308,7 +12398,6 @@ packages:
       is-generator-function: 1.0.10
       is-typed-array: 1.1.12
       which-typed-array: 1.1.13
-    dev: true
 
   /utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
@@ -12673,7 +12762,6 @@ packages:
       for-each: 0.3.3
       gopd: 1.0.1
       has-tostringtag: 1.0.0
-    dev: true
 
   /which@1.2.4:
     resolution: {integrity: sha512-zDRAqDSBudazdfM9zpiI30Fu9ve47htYXcGi3ln0wfKu2a7SmrT6F3VDoYONu//48V8Vz4TdCRNPjtvyRO3yBA==}

--- a/vite/package.json
+++ b/vite/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
+    "@polkadot-api/rollup-plugin-descriptor-treeshake": "workspace:*",
     "@types/node": "^20.4.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6",

--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -1,7 +1,8 @@
+import descriptorTreeShake from "@polkadot-api/rollup-plugin-descriptor-treeshake"
 import { defineConfig } from "vite"
 
 export default defineConfig({
-  plugins: [],
+  plugins: [descriptorTreeShake("./src/codegen")],
   build: {
     target: "esnext",
     rollupOptions: {


### PR DESCRIPTION
My attempt at solving #198 through method [2a].

I've built a rollup plugin (which is compatible with vite) that given the path to a codegen folder, detects calls to `createClient` using the generated descriptors, traces their usages and removes the unused descriptors from the build.

With the current example of `vite/src/main.ts`, the minified code is shaved by ~50kB:

```
minified
dist/assets/index-9b9328ce.js                       140.46 kB │ gzip:    53.27 kB
dist/assets/index-91969805.js                        89.86 kB │ gzip:    31.66 kB
```

Resulting built code without the plugin:

<img width="1217" alt="Screenshot 2023-11-26 at 10 40 36" src="https://github.com/paritytech/polkadot-api/assets/5365487/39ede226-9bfc-4062-9a5d-b407e984ecf9">

Resulting built code with the plugin:

<img width="1111" alt="Screenshot 2023-11-26 at 10 42 01" src="https://github.com/paritytech/polkadot-api/assets/5365487/be678726-c99e-4eea-a17e-00ebbce98a77">

This plugin is able to trace many common cases:

```ts
import { createClient } from "@polkadot-api/client";
import testDescriptors from "./codegen/test";

function transfer(alexa: Account, billy: Account, amount: bigint) {
  // Will be tracked even if `client` is defined further down in the AST
  client.tx.Balances.transfer_keep_alive.submit$(/* ... */);
}

const client = createClient(chain.connect, testDescriptors);

const { tx: transactions } = client;

// Will also be tracked even after the rename
const data = transaction.Slots.clear_all_leases.getCallData(0);

// Any file importing `transactions` and using it will also be tracked
export { transactions };
```

And it also covers the minimum for source map support. This can be used as an initial version where it covers many of the happy paths. There are still a few tweaks to improve and some challenges to solve:

- Computed properties `client.tx.Balances[method]`, or any thing that has to get solved in runtime. Currently it ignores it, but I would suggest bailing out from removing any symbol when detecting such cases.
- Passing tracking variables through function arguments instead of directly referencing them. This could technically be solved by finding out the call arguments, with a few edge cases, but it will get more complex and tricky if the function is defined in a separate file.

```ts
function transfer(
  selectedClient: typeof client,
  alexa: Account,
  billy: Account,
  amount: bigint
) {
  // Currently won't be tracked :(
  selectedClient.tx.Balances.transfer_keep_alive.submit$(/* ... */);
}
const client = createClient(chain.connect, testDescriptors);
transfer(client, alexa, billy, 30n);
```

- Currently destructuring is only supported one level deep, it should support going further down: `const { tx: { Balances }} = client`. There are other assignment patterns defined in the AST types that need to be handled as well.
- Currently source maps just link the original code with all the symbols to the optimised code as a block, but doesn't go into the detail of which variables come exactly from where. It's just a technicality, but this is enough to let the consumer debug through the code.

I've added this as a new package `rollup-plugin-descriptor-treeshake`. I'm happy to change anything you might need, or if you think you want to use a different approach altoghether it's also fine; I just found this feature request interesting :).