### PR TITLE
Fix getMetadata in experiments

### DIFF
--- a/experiments/src/getMetadata.ts
+++ b/experiments/src/getMetadata.ts
@@ -1,5 +1,5 @@
 import {
-  ScProvider,
+  getScProvider,
   WellKnownChain,
   ConnectProvider,
 } from "@polkadot-api/sc-provider"
@@ -11,13 +11,15 @@ import {
   Tuple,
 } from "@polkadot-api/substrate-bindings"
 
-const smProvider = ScProvider(
+const scProvider = getScProvider()
+
+const smProvider = scProvider(
   WellKnownChain.polkadot /*, {
   embeddedNodeConfig: {
     maxLogLevel: 9,
   },
 }*/,
-)
+).relayChain
 
 const withLogsProvider = (input: ConnectProvider): ConnectProvider => {
   return (onMsg) => {


### PR DESCRIPTION
Experiments ts `getMetadata` was throwing error:
```
file:///home/wirednkod/Documents/repos/parity/ts/polkadot-api/experiments/dist/main.js:3
  ScProvider,
  ^^^^^^^^^^
SyntaxError: The requested module '@polkadot-api/sc-provider' does not provide an export named 'ScProvider'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:123:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:191:5)
    at async ModuleLoader.import (node:internal/modules/esm/loader:336:24)
    at async loadESM (node:internal/process/esm_loader:34:7)
    at async handleMainPromise (node:internal/modules/run_main:106:12)
```