### PR TITLE
feat(client): best-blocks

### DIFF
--- a/experiments/package.json
+++ b/experiments/package.json
@@ -7,6 +7,7 @@
   "main": "index.js",
   "scripts": {
     "start": "tsup-node src/main.ts --watch --clean --format esm --platform node --onSuccess \"node --enable-source-maps dist/main.js\"",
+    "best-blocks": "tsup-node src/best-blocks.ts --watch --clean --format esm --platform node --onSuccess \"node --enable-source-maps dist/best-blocks.js\"",
     "nominators": "tsup-node src/all-nominators.ts --clean --format esm --platform node --onSuccess \"node --enable-source-maps dist/all-nominators.js\"",
     "viewer": "tsup-node src/viewer.ts --clean --format esm --platform node --onSuccess \"node --enable-source-maps dist/viewer.js\"",
     "tx": "tsup-node src/tx.ts --clean --format esm --platform node --onSuccess \"node --enable-source-maps dist/tx.js\"",

--- a/experiments/src/best-blocks.ts
+++ b/experiments/src/best-blocks.ts
@@ -1,0 +1,19 @@
+import { getObservableClient } from "@polkadot-api/client"
+import { getScProvider, WellKnownChain } from "@polkadot-api/sc-provider"
+import { createClient } from "@polkadot-api/substrate-client"
+
+const scProvider = getScProvider()
+const { relayChain } = scProvider(WellKnownChain.polkadot)
+
+const client = getObservableClient(createClient(relayChain))
+
+const chainHead = client.chainHead$()
+
+chainHead.bestBlocks$.subscribe({
+  next(v) {
+    console.log(v)
+  },
+  error(e) {
+    console.error(e)
+  },
+})

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -104,6 +104,8 @@ export const createClient: CreateClient = (connect, descriptors) => {
 
   return {
     finalized$: chainHead.finalized$,
+    bestBlock$: chainHead.bestBlock$,
+    bestBlocks$: chainHead.bestBlocks$,
     ...mapObject(descriptors, (des) =>
       createNamespace(des, createTxFromAddress, chainHead, client),
     ),

--- a/packages/client/src/observableClient/chainHead/index.ts
+++ b/packages/client/src/observableClient/chainHead/index.ts
@@ -1,2 +1,2 @@
-export type { RuntimeContext } from "./chainHead"
+export type { RuntimeContext, BlockHeaderWithHash } from "./chainHead"
 export { default } from "./chainHead"

--- a/packages/client/src/observableClient/chainHead/streams/best-block.ts
+++ b/packages/client/src/observableClient/chainHead/streams/best-block.ts
@@ -1,0 +1,96 @@
+import type {
+  BestBlockChanged,
+  FollowEventWithRuntime,
+} from "@polkadot-api/substrate-client"
+import {
+  Observable,
+  Subject,
+  Subscription,
+  concatMap,
+  startWith,
+  tap,
+  withLatestFrom,
+} from "rxjs"
+
+import { combineLatest, filter, map } from "rxjs"
+import { shareLatest } from "@/utils"
+import { BlockHeader } from "@polkadot-api/substrate-bindings"
+
+export const getBestBlock$ = (follow$: Observable<FollowEventWithRuntime>) =>
+  follow$.pipe(
+    filter((e): e is BestBlockChanged => e.type === "bestBlockChanged"),
+    map((e) => e.bestBlockHash),
+    shareLatest,
+  )
+
+export type BlockHeaderWithHash = BlockHeader & { hash: string }
+
+export const getBestBlocks$ = (
+  best$: Observable<string>,
+  finalized$: Observable<string>,
+  getHeader$: (hash: string) => Observable<BlockHeaderWithHash>,
+): Observable<Array<BlockHeaderWithHash>> => {
+  const _current$ = new Subject<Map<string, BlockHeaderWithHash>>()
+  const getBlocks$ = (
+    best: string,
+    finalized: string,
+    current: Map<string, BlockHeaderWithHash>,
+  ): Observable<Map<string, BlockHeaderWithHash>> =>
+    new Observable((observer) => {
+      const result = new Map<string, BlockHeaderWithHash>()
+      let sub: Subscription
+
+      const process = (hash: string) => {
+        if (hash === finalized) {
+          observer.next(result)
+          observer.complete()
+          return
+        }
+
+        const header = current.get(hash)
+        if (header) {
+          result.set(hash, header)
+          process(header.parentHash)
+          return
+        }
+
+        sub = getHeader$(hash).subscribe({
+          next(header) {
+            result.set(hash, header)
+            process(header.parentHash)
+          },
+          error(e) {
+            observer.error(e)
+          },
+        })
+      }
+
+      process(best)
+
+      return () => {
+        sub?.unsubscribe()
+      }
+    })
+
+  return combineLatest({ best: best$, finalized: finalized$ }).pipe(
+    withLatestFrom(_current$.pipe(startWith(new Map()))),
+    concatMap(([{ best, finalized }, current]) =>
+      getBlocks$(best, finalized, current).pipe(
+        tap((x) => {
+          _current$.next(x)
+        }),
+        map((state) => {
+          const result: Array<BlockHeaderWithHash> = []
+          let current = best
+          while (current !== finalized) {
+            const value = state.get(current)!
+            result.push(value)
+            current = value.parentHash
+          }
+          return result
+        }),
+      ),
+    ),
+    shareLatest,
+  )
+}

--- a/packages/client/src/observableClient/index.ts
+++ b/packages/client/src/observableClient/index.ts
@@ -1,2 +1,2 @@
-export type { RuntimeContext } from "./chainHead"
+export type { RuntimeContext, BlockHeaderWithHash } from "./chainHead"
 export { getObservableClient } from "./getObservableClient"

--- a/packages/substrate-bindings/src/codecs/blockHeader.ts
+++ b/packages/substrate-bindings/src/codecs/blockHeader.ts
@@ -1,4 +1,12 @@
-import { Bytes, Enum, Struct, Vector, _void, enhanceCodec } from "scale-ts"
+import {
+  Bytes,
+  CodecType,
+  Enum,
+  Struct,
+  Vector,
+  _void,
+  enhanceCodec,
+} from "scale-ts"
 import { Hex } from "./Hex"
 import { compactNumber } from "./compact"
 
@@ -34,3 +42,5 @@ export const blockHeader = Struct({
   extrinsicRoot: hex32,
   digests: Vector(diggest),
 })
+
+export type BlockHeader = CodecType<typeof blockHeader>


### PR DESCRIPTION
closes #218 

It adds 2 new APIs:
1) An API that simply observes the current best block hash
2) A more useful API which observes the current list of best-block headers. The list changes any time that either the current finalized and/or the current best block changes. Basically, it observes the "gap" of blocks from the currently finalized block to the best-block.

A new experiment has been added in order to easily test this new APIs.