### PR TITLE
feat: use turbo repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ jobs:
         node-version: [18.x, 20.x]
     steps:
       - uses: actions/checkout@v3.5.3
+      - uses: actions/cache@v3
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-${{ matrix.node-version }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-turbo-
       - uses: pnpm/action-setup@v2
         with:
           version: 8
@@ -27,12 +33,8 @@ jobs:
           cache: pnpm
       - name: Install deps
         run: pnpm install
-      - name: Build
-        run: pnpm build
-      - name: Run lint
-        run: pnpm lint
-      - name: Run tests
-        run: pnpm test
+      - name: Build, Test and Lint
+        run: pnpm turbo build test lint
       - name: Run Integration Tests
         run: pnpm test:ci
 
@@ -42,10 +44,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.3
+      - uses: actions/cache@v3
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-20.x-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-20.x-turbo-
       - uses: pnpm/action-setup@v2
         with:
           version: 8
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js 20.x
         uses: actions/setup-node@v3
         with:
           node-version: 20.x
@@ -54,7 +62,7 @@ jobs:
       - name: Install deps
         run: pnpm install
       - name: Build
-        run: pnpm build
+        run: pnpm turbo build
       - name: Pack
         run: |
           pnpm dlx lerna init

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install deps
         run: pnpm install
       - name: Build, Test and Lint
-        run: pnpm turbo build test lint
+        run: pnpm turbo build test lint --cache-dir=.turbo
       - name: Run Integration Tests
         run: pnpm test:ci
 
@@ -62,7 +62,7 @@ jobs:
       - name: Install deps
         run: pnpm install
       - name: Build
-        run: pnpm turbo build
+        run: pnpm turbo build --cache-dir=.turbo
       - name: Pack
         run: |
           pnpm dlx lerna init

--- a/.github/workflows/zombienet.yml
+++ b/.github/workflows/zombienet.yml
@@ -12,6 +12,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.5.3
+      - uses: actions/cache@v3
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-18.x-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-18.x-turbo-
       - uses: pnpm/action-setup@v2
         with:
           version: 8
@@ -23,7 +29,7 @@ jobs:
       - name: build
         run: |
           pnpm install
-          pnpm build
+          pnpm turbo build
       - name: Get zombienet
         run: |
           curl -L -O https://github.com/paritytech/zombienet/releases/download/v1.3.71/zombienet-linux-x64

--- a/.github/workflows/zombienet.yml
+++ b/.github/workflows/zombienet.yml
@@ -29,7 +29,7 @@ jobs:
       - name: build
         run: |
           pnpm install
-          pnpm turbo build
+          pnpm turbo build --cache-dir=.turbo
       - name: Get zombienet
         run: |
           curl -L -O https://github.com/paritytech/zombienet/releases/download/v1.3.71/zombienet-linux-x64

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ experiments/dist/**
 examples/*/dist/**
 .vscode
 .pnpm-store
+.turbo

--- a/examples/decode-viewer/turbo.json
+++ b/examples/decode-viewer/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "pipeline": {
+    "build": {
+      "inputs": ["vite.config.js"]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prettier": "^3.1.0",
     "tslib": "^2.4.0",
     "tsup": "^8.0.1",
+    "turbo": "^1.11.3",
     "typescript": "^5.3.2",
     "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^0.34.1"

--- a/packages/cli/turbo.json
+++ b/packages/cli/turbo.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "pipeline": {
+    "build": {
+      "inputs": ["tsconfig.build.json"],
+      "outputs": ["bin/**"]
+    },
+    "test": {
+      "inputs": ["vitest.config.ts"]
+    }
+  }
+}

--- a/packages/rollup-plugin-descriptor-treeshake/turbo.json
+++ b/packages/rollup-plugin-descriptor-treeshake/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "pipeline": {
+    "build": {
+      "inputs": ["rollup.config.js"]
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       tsup:
         specifier: ^8.0.1
         version: 8.0.1(typescript@5.3.2)
+      turbo:
+        specifier: ^1.11.3
+        version: 1.11.3
       typescript:
         specifier: ^5.3.2
         version: 5.3.2
@@ -10928,6 +10931,66 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - ts-node
+    dev: true
+
+  /turbo-darwin-64@1.11.3:
+    resolution: {integrity: sha512-IsOOg2bVbIt3o/X8Ew9fbQp5t1hTHN3fGNQYrPQwMR2W1kIAC6RfbVD4A9OeibPGyEPUpwOH79hZ9ydFH5kifw==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-darwin-arm64@1.11.3:
+    resolution: {integrity: sha512-FsJL7k0SaPbJzI/KCnrf/fi3PgCDCjTliMc/kEFkuWVA6Httc3Q4lxyLIIinz69q6JTx8wzh6yznUMzJRI3+dg==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-linux-64@1.11.3:
+    resolution: {integrity: sha512-SvW7pvTVRGsqtSkII5w+wriZXvxqkluw5FO/MNAdFw0qmoov+PZ237+37/NgArqE3zVn1GX9P6nUx9VO+xcQAg==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-linux-arm64@1.11.3:
+    resolution: {integrity: sha512-YhUfBi1deB3m+3M55X458J6B7RsIS7UtM3P1z13cUIhF+pOt65BgnaSnkHLwETidmhRh8Dl3GelaQGrB3RdCDw==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-windows-64@1.11.3:
+    resolution: {integrity: sha512-s+vEnuM2TiZuAUUUpmBHDr6vnNbJgj+5JYfnYmVklYs16kXh+EppafYQOAkcRIMAh7GjV3pLq5/uGqc7seZeHA==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-windows-arm64@1.11.3:
+    resolution: {integrity: sha512-ZR5z5Zpc7cASwfdRAV5yNScCZBsgGSbcwiA/u3farCacbPiXsfoWUkz28iyrx21/TRW0bi6dbsB2v17swa8bjw==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo@1.11.3:
+    resolution: {integrity: sha512-RCJOUFcFMQNIGKSjC9YmA5yVP1qtDiBA0Lv9VIgrXraI5Da1liVvl3VJPsoDNIR9eFMyA/aagx1iyj6UWem5hA==}
+    hasBin: true
+    optionalDependencies:
+      turbo-darwin-64: 1.11.3
+      turbo-darwin-arm64: 1.11.3
+      turbo-linux-64: 1.11.3
+      turbo-linux-arm64: 1.11.3
+      turbo-windows-64: 1.11.3
+      turbo-windows-arm64: 1.11.3
     dev: true
 
   /tween-functions@1.2.0:

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["tsconfig.base.json", "vitest.config.ts"],
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "inputs": ["tsconfig.json", "src/**"],
+      "outputs": ["dist/**"]
+    },
+    "test": {
+      "dependsOn": ["build"],
+      "inputs": ["test/**", "tests/**"]
+    },
+    "lint": {}
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -11,6 +11,8 @@
       "dependsOn": ["build"],
       "inputs": ["test/**", "tests/**"]
     },
-    "lint": {}
+    "lint": {
+      "dependsOn": ["build"]
+    }
   }
 }

--- a/vite/turbo.json
+++ b/vite/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "pipeline": {
+    "build": {
+      "inputs": ["vite.config.js"]
+    }
+  }
+}


### PR DESCRIPTION
Add [turbo](https://turbo.build/) incremental build system

For example, the `build` step in the `pack` job uses `turbo` cache for the `build` script and it takes 1s
<img width="1475" alt="image" src="https://github.com/paritytech/polkadot-api/assets/1209171/d8adb331-7d9d-4087-afee-64080820d017">
